### PR TITLE
Authenticates as the proxy instead of client

### DIFF
--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/StandardIRODSAuth.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/StandardIRODSAuth.java
@@ -45,7 +45,7 @@ public class StandardIRODSAuth extends AuthMechanism {
 		String response = challengeResponse(cachedChallenge,
 				irodsAccount.getPassword(), irodsCommands);
 		AuthResponseInp authResponse_PI = new AuthResponseInp(
-				irodsAccount.getUserName(), response);
+				irodsAccount.getProxyName(), response);
 
 		// should be a header with no body if successful
 		irodsCommands.irodsFunction(RequestTypes.RODS_API_REQ.getRequestType(),


### PR DESCRIPTION
In the usual case where the proxy user is the same as the client user, it didn't matter which user name was used to authenticate. When they are different, authentication needs occur for the proxy user.