### PR TITLE
Remove trim() from values in AVU queries

### DIFF
--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/DataAOHelper.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/DataAOHelper.java
@@ -827,21 +827,21 @@ public final class DataAOHelper extends AOHelper {
 					RodsGenQueryEnum.COL_META_DATA_ATTR_NAME,
 					BuilderQueryUtils
 							.translateAVUQueryElementOperatorToBuilderQueryCondition(queryElement),
-					queryElement.getValue().trim());
+					queryElement.getValue());
 
 		} else if (queryElement.getAvuQueryPart() == AVUQueryElement.AVUQueryPart.VALUE) {
 			builder.addConditionAsGenQueryField(
 					RodsGenQueryEnum.COL_META_DATA_ATTR_VALUE,
 					BuilderQueryUtils
 							.translateAVUQueryElementOperatorToBuilderQueryCondition(queryElement),
-					queryElement.getValue().trim());
+					queryElement.getValue());
 
 		} else if (queryElement.getAvuQueryPart() == AVUQueryElement.AVUQueryPart.UNITS) {
 			builder.addConditionAsGenQueryField(
 					RodsGenQueryEnum.COL_META_DATA_ATTR_UNITS,
 					BuilderQueryUtils
 							.translateAVUQueryElementOperatorToBuilderQueryCondition(queryElement),
-					queryElement.getValue().trim());
+					queryElement.getValue());
 		} else {
 			throw new JargonQueryException("unable to resolve AVU Query part");
 		}

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/aohelper/CollectionAOHelper.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/aohelper/CollectionAOHelper.java
@@ -234,21 +234,21 @@ public class CollectionAOHelper extends AOHelper {
 					RodsGenQueryEnum.COL_META_COLL_ATTR_NAME,
 					BuilderQueryUtils
 					.translateAVUQueryElementOperatorToBuilderQueryCondition(queryElement),
-					queryElement.getValue().trim());
+					queryElement.getValue());
 
 		} else if (queryElement.getAvuQueryPart() == AVUQueryElement.AVUQueryPart.VALUE) {
 			builder.addConditionAsGenQueryField(
 					RodsGenQueryEnum.COL_META_COLL_ATTR_VALUE,
 					BuilderQueryUtils
 					.translateAVUQueryElementOperatorToBuilderQueryCondition(queryElement),
-					queryElement.getValue().trim());
+					queryElement.getValue());
 
 		} else if (queryElement.getAvuQueryPart() == AVUQueryElement.AVUQueryPart.UNITS) {
 			builder.addConditionAsGenQueryField(
 					RodsGenQueryEnum.COL_META_COLL_ATTR_UNITS,
 					BuilderQueryUtils
 					.translateAVUQueryElementOperatorToBuilderQueryCondition(queryElement),
-					queryElement.getValue().trim());
+					queryElement.getValue());
 		} else {
 			throw new JargonQueryException("unable to resolve AVU Query part");
 		}


### PR DESCRIPTION
This was mistakenly added when a lot of other trim()s were moving around
in the codebase, but AVU fields can have leading and trailing space, so
trimming these values makes it impossible to use the AVU Query interface
to look up AVUs with space of that sort.

(I'm part of CyVerse/iPlant; this caused a bug due to changes made in https://github.com/cyverse/DE/commit/989bf1695acf4c905795a212c45a4105b106d666 -- I don't have experience committing to this project itself, of course, so guidance welcome)