### PR TITLE
Remove an extra trim() for AVU queries

### DIFF
--- a/jargon-core/src/main/java/org/irods/jargon/core/query/AVUQueryElement.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/query/AVUQueryElement.java
@@ -74,7 +74,7 @@ public class AVUQueryElement {
 
 		this.avuQueryPart = avuQueryPart;
 		this.operator = operator;
-		this.value = value.trim();
+		this.value = value;
 		this.valueEndOfRange = valueEndOfRange;
 		this.valuesTable = null;
 


### PR DESCRIPTION
Followup to #180 upon testing it with our use case; I'd missed a trim() in AVUQueryElement.java