### PR TITLE
Allow modifications of resources

### DIFF
--- a/jargon-core/src/main/java/org/irods/jargon/core/packinstr/GeneralAdminInpForResources.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/packinstr/GeneralAdminInpForResources.java
@@ -78,6 +78,71 @@ public class GeneralAdminInpForResources extends GeneralAdminInp {
 
 	}
 
+  /**
+   * Generate the packing instruction suitable for modifying a
+   * <code>Resource</code>
+   *
+   * @param Resource
+   *            {@link Resource} to be added to iRODS.
+   * @param option
+   *            attribute to modify (any of "type", "status", "comment", "info", "context").
+   * @return {@link GeneralAdminInp}
+   * @throws JargonException
+   */
+  public static final GeneralAdminInpForResources instanceForModifyResource(
+      final Resource resource, String option) throws JargonException {
+
+    if (resource == null) {
+      throw new IllegalArgumentException("null resource");
+    }
+
+    if (resource.getName() == null || resource.getName().isEmpty()) {
+      throw new IllegalArgumentException("resource name is null or empty");
+    }
+
+    String newValue;
+    switch (option) {
+      case "type" :
+        if (resource.getType() == null || resource.getType().isEmpty()) {
+          throw new IllegalArgumentException("null or empty type");
+        }
+        newValue = resource.getType();
+        break;
+      case "status" :
+        if (resource.getStatus() == null) {
+          throw new IllegalArgumentException("null status");
+        }
+        newValue = resource.getStatus();
+        break;
+      case "comment" : 
+        if (resource.getComment() == null) {
+          throw new IllegalArgumentException("null comment string");
+        }
+        newValue = resource.getComment();
+        break;
+      case "info" :
+        if (resource.getInfo() == null) {
+          throw new IllegalArgumentException("null info string");
+        }
+        newValue = resource.getInfo();
+        break;
+      case "context" : 
+        if (resource.getContextString() == null) {
+          throw new IllegalArgumentException("Null context string");
+        }
+        newValue = resource.getContextString();
+        break;
+      default :
+        throw new IllegalArgumentException("Impossible to change " + option + " attribute for resource " + resource.getName());
+    }
+
+    return new GeneralAdminInpForResources("modify", "resource",
+        resource.getName(), option, newValue,
+        BLANK, BLANK, BLANK, BLANK, BLANK,
+        GEN_ADMIN_INP_API_NBR);
+
+  }
+
 	/**
 	 * Packing instruction to add a child to a resource
 	 *

--- a/jargon-core/src/main/java/org/irods/jargon/core/packinstr/ModAvuMetadataInp.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/packinstr/ModAvuMetadataInp.java
@@ -34,7 +34,7 @@ public class ModAvuMetadataInp extends AbstractIRODSPackingInstruction {
 	 * Modify action
 	 */
 	public enum ActionType {
-		ADD, REMOVE, MOD
+		ADD, REMOVE, MOD, SET
 	}
 
 	private final String targetIdentifier;
@@ -161,6 +161,21 @@ public class ModAvuMetadataInp extends AbstractIRODSPackingInstruction {
 			final String targetIdentifier, final AvuData avuData) {
 		return new ModAvuMetadataInp(targetIdentifier,
 				MetadataTargetType.RESOURCE, avuData, null, ActionType.ADD);
+	}
+
+  	/**
+	 * Create an instance of the packing instruction that will set the AVU to a
+	 * resource.
+	 *
+	 * @param targetIdentifier
+	 *            <code>String</code> with the path or unique name of the object
+	 *            to which the metadata will be added
+	 * @return
+	 */
+	public static final ModAvuMetadataInp instanceForSetResourceMetadata(
+			final String targetIdentifier, final AvuData avuData) {
+		return new ModAvuMetadataInp(targetIdentifier,
+				MetadataTargetType.RESOURCE, avuData, null, ActionType.SET);
 	}
 
 	/**
@@ -295,6 +310,8 @@ public class ModAvuMetadataInp extends AbstractIRODSPackingInstruction {
 			argList.add("rmw");
 		} else if (actionType == ActionType.MOD) {
 			argList.add("mod");
+		} else if (actionType == ActionType.SET) {
+			argList.add("set");
 		}
 
 		if (metadataTargetType == MetadataTargetType.COLLECTION) {

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/ResourceAO.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/ResourceAO.java
@@ -144,6 +144,20 @@ public interface ResourceAO extends IRODSAccessObject {
 			JargonException;
 
 	/**
+	 * Set AVU metadata for this resource.
+	 * Be aware setting a metadata forces just this one attribute name to exist (it will delete all the possibly existing ones)
+	 * @param resourceName
+	 *            <code>String</code> with the name of the resource
+	 * @param avuData
+	 *            {@link org.irods.jargon.core.pub.domain.AvuData}
+	 * @throws JargonException
+	 * @throws InvalidResourceException
+	 *             when resource is missing
+	 */
+	void setAVUMetadata(String resourceName, AvuData avuData)
+			throws InvalidResourceException, JargonException;
+
+	/**
 	 * Remove Resource AVU data, silently ignore if metadata is not found.
 	 *
 	 * @param resourceName
@@ -167,6 +181,17 @@ public interface ResourceAO extends IRODSAccessObject {
 	 */
 	void addResource(final Resource resource) throws DuplicateDataException,
 	JargonException;
+
+	/**
+	 * Modify a resource
+	 *
+	 * @param resource
+	 *            {@link Resource} to be modified
+	 * @param what
+	 *            what is modified among type, status, comment, info, context
+	 * @throws JargonException
+	 */
+	void modifyResource(final Resource resource, String what) throws JargonException;
 
 	void deleteResource(final String resourceName) throws Exception;
 

--- a/jargon-core/src/main/java/org/irods/jargon/core/query/RodsGenQueryEnum.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/query/RodsGenQueryEnum.java
@@ -45,7 +45,7 @@ public enum RodsGenQueryEnum {
 																																													"DATA_STATUS", 414), COL_D_DATA_CHECKSUM("DATA_CHECKSUM", 415), COL_D_EXPIRY(
 																																															"DATA_EXPIRY", 416), COL_D_MAP_ID("DATA_MAP_ID", 417), COL_D_COMMENTS(
 																																																	"DATA_COMMENTS", 418), COL_D_CREATE_TIME("DATA_CREATE_TIME", 419), COL_D_MODIFY_TIME(
-																																																			"DATA_MODIFY_TIME", 420), COL_D_DATA_MODE("DATA_MODE", 421),
+																																																			"DATA_MODIFY_TIME", 420), COL_D_DATA_MODE("DATA_MODE", 421), COL_D_RESC_HIER("DATA_RESC_HIER", 422),COL_D_RESC_ID("DATA_RESC_ID", 423),
 																																																			// data access
 																																																			COL_DATA_ACCESS_TYPE("DATA_ACCESS_TYPE", 700), COL_DATA_ACCESS_NAME(
 																																																					"DATA_ACCESS_NAME", 701), COL_DATA_TOKEN_NAMESPACE(


### PR DESCRIPTION
This commits adds methods to
- modify the setting of a resource `ResourceAO.modifyResource()` with a new `GeneralAdminInpForResources.instanceForModifyResource()`
- assign a single AVU to a resource `ResourceAO.setAVUMetadata()` with a new  `ModAvuMetadataInp.instanceForSetResourceMetadata()`

It also adds forgotten new columns for query: `DATA_RESC_HIER` and `DATA_RESC_ID`

Fixes #201.