### PR TITLE
Remove thread local map for AbstractIRODSMidLevelProtocol. Fix #199.

### DIFF
--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/IRODSFileSystem.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/IRODSFileSystem.java
@@ -3,8 +3,6 @@
  */
 package org.irods.jargon.core.pub;
 
-import java.util.Map;
-
 import org.irods.jargon.core.connection.AbstractIRODSMidLevelProtocol;
 import org.irods.jargon.core.connection.IRODSAccount;
 import org.irods.jargon.core.connection.IRODSProtocolManager;
@@ -217,8 +215,8 @@ public final class IRODSFileSystem {
 	 * @return {@link AbstractIRODSMidLevelProtocol} that represent
 	 *         protocol-level connection to iRODS (above the socket level)
 	 */
-	public Map<String, AbstractIRODSMidLevelProtocol> getConnectionMap() {
-		return irodsSession.getIRODSCommandsMap();
+	public AbstractIRODSMidLevelProtocol getConnection() {
+		return irodsSession.getIrodsMidLevelProtocol();
 
 	}
 

--- a/jargon-core/src/test/java/org/irods/jargon/core/pub/DataTransferOperationsImplTest.java
+++ b/jargon-core/src/test/java/org/irods/jargon/core/pub/DataTransferOperationsImplTest.java
@@ -736,7 +736,7 @@ public class DataTransferOperationsImplTest {
 		// there should only be one connection in the session map (secondary
 		// account should have been closed
 		Assert.assertNull("session from reroute leaking",
-				irodsFileSystem.getConnectionMap());
+				irodsFileSystem.getConnection());
 
 	}
 
@@ -801,7 +801,7 @@ public class DataTransferOperationsImplTest {
 		// there should only be one connection in the session map (secondary
 		// account should have been closed
 		Assert.assertNull("session from reroute leaking",
-				irodsFileSystem.getConnectionMap());
+				irodsFileSystem.getConnection());
 
 	}
 

--- a/jargon-core/src/test/java/org/irods/jargon/core/pub/IRODSFileSystemTest.java
+++ b/jargon-core/src/test/java/org/irods/jargon/core/pub/IRODSFileSystemTest.java
@@ -113,7 +113,7 @@ public class IRODSFileSystemTest {
 				.getIRODSAccessObjectFactory();
 		irodsAccessObjectFactory.getDataObjectAO(irodsAccount);
 		irodsFileSystem.close();
-		Assert.assertNull(irodsFileSystem.getConnectionMap());
+		Assert.assertNull(irodsFileSystem.getConnection());
 	}
 
 	/**
@@ -130,7 +130,7 @@ public class IRODSFileSystemTest {
 		irodsAccessObjectFactory.getDataObjectAO(irodsAccount);
 		irodsFileSystem.close();
 		irodsFileSystem.close();
-		Assert.assertNull(irodsFileSystem.getConnectionMap());
+		Assert.assertNull(irodsFileSystem.getConnection());
 	}
 
 	/**
@@ -148,16 +148,12 @@ public class IRODSFileSystemTest {
 
 		irodsFileSystem.getIRODSFileFactory(irodsAccount);
 		irodsFileSystem.getIRODSFileFactory(irodsAccount2);
-		Assert.assertNotNull(irodsFileSystem.getConnectionMap());
-		Assert.assertEquals(2, irodsFileSystem.getConnectionMap().values()
-				.size());
+		Assert.assertNotNull(irodsFileSystem.getConnection());
 
 		irodsFileSystem.close(irodsAccount);
-		Assert.assertEquals(1, irodsFileSystem.getConnectionMap().values()
-				.size());
 		irodsFileSystem.close(irodsAccount2);
 
-		Assert.assertNull(irodsFileSystem.getConnectionMap());
+		Assert.assertNull(irodsFileSystem.getConnection());
 	}
 
 }

--- a/jargon-core/src/test/java/org/irods/jargon/core/pub/io/IRODSFileInputStreamTest.java
+++ b/jargon-core/src/test/java/org/irods/jargon/core/pub/io/IRODSFileInputStreamTest.java
@@ -183,7 +183,7 @@ public class IRODSFileInputStreamTest {
 		Assert.assertTrue("did not get instance of session closing stream",
 				fis instanceof SessionClosingIRODSFileInputStream);
 		Assert.assertNull("session from reroute leaking",
-				irodsFileSystem.getConnectionMap());
+				irodsFileSystem.getConnection());
 
 	}
 
@@ -244,7 +244,7 @@ public class IRODSFileInputStreamTest {
 		Assert.assertFalse("did not get instance of session closing stream",
 				fis instanceof SessionClosingIRODSFileInputStream);
 		Assert.assertNull("session from reroute leaking",
-				irodsFileSystem.getConnectionMap());
+				irodsFileSystem.getConnection());
 
 	}
 

--- a/jargon-core/src/test/java/org/irods/jargon/core/pub/io/IRODSFileOutputStreamTest.java
+++ b/jargon-core/src/test/java/org/irods/jargon/core/pub/io/IRODSFileOutputStreamTest.java
@@ -701,7 +701,7 @@ public class IRODSFileOutputStreamTest {
 				"did not get session closing stream for re-route",
 				irodsFileOutputStream instanceof SessionClosingIRODSFileOutputStream);
 		Assert.assertNull("session from reroute leaking",
-				irodsFileSystem.getConnectionMap());
+				irodsFileSystem.getConnection());
 
 	}
 
@@ -735,7 +735,7 @@ public class IRODSFileOutputStreamTest {
 		Assert.assertTrue("did not get normal stream for re-route",
 				irodsFileOutputStream instanceof IRODSFileOutputStream);
 		Assert.assertNull("session from reroute leaking",
-				irodsFileSystem.getConnectionMap());
+				irodsFileSystem.getConnection());
 
 	}
 

--- a/jargon-core/src/test/java/org/irods/jargon/core/pub/io/RODSFIleInputStreamForSoftLinksTest.java
+++ b/jargon-core/src/test/java/org/irods/jargon/core/pub/io/RODSFIleInputStreamForSoftLinksTest.java
@@ -183,7 +183,7 @@ public class RODSFIleInputStreamForSoftLinksTest {
 		Assert.assertTrue("did not get instance of session closing stream",
 				fis instanceof SessionClosingIRODSFileInputStream);
 		Assert.assertNull("session from reroute leaking",
-				irodsFileSystem.getConnectionMap());
+				irodsFileSystem.getConnection());
 
 	}
 
@@ -237,7 +237,7 @@ public class RODSFIleInputStreamForSoftLinksTest {
 		Assert.assertFalse("did not get instance of session closing stream",
 				fis instanceof SessionClosingIRODSFileInputStream);
 		Assert.assertNull("session from reroute leaking",
-				irodsFileSystem.getConnectionMap());
+				irodsFileSystem.getConnection());
 
 	}
 


### PR DESCRIPTION
From a client point of view I expect two references to `IRODSFileSystemAO` to be independent and and not share state when accessed from the same thread.