### PR TITLE
update jglobus library to 2.0.6 (which is in mavenCentral)

### DIFF
--- a/jargon-core/pom.xml
+++ b/jargon-core/pom.xml
@@ -25,11 +25,6 @@
 			<artifactId>commons-lang</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.claymoresystems</groupId>
-			<artifactId>puretls</artifactId>
-			<type>jar</type>
-		</dependency>
-		<dependency>
 			<groupId>org.jglobus</groupId>
 			<artifactId>gss</artifactId>
 			<type>jar</type>

--- a/jargon-core/pom.xml
+++ b/jargon-core/pom.xml
@@ -30,8 +30,8 @@
 			<type>jar</type>
 		</dependency>
 		<dependency>
-			<groupId>org.globus.jglobus</groupId>
-			<artifactId>cog-jglobus</artifactId>
+			<groupId>org.jglobus</groupId>
+			<artifactId>gss</artifactId>
 			<type>jar</type>
 			<exclusions>
 				<exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -56,21 +56,6 @@
 			<name>Open Source Geospatial Foundation Repository</name>
 			<url>http://download.osgeo.org/webdav/geotools/</url>
 		</repository>
-		<repository>
-			<id>renci.repository</id>
-			<name>renci.repository</name>
-			<url>http://ci-dev.renci.org/nexus/content/repositories/public</url>
-			<releases>
-				<enabled>true</enabled>
-				<updatePolicy>always</updatePolicy>
-				<checksumPolicy>warn</checksumPolicy>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-				<updatePolicy>never</updatePolicy>
-				<checksumPolicy>fail</checksumPolicy>
-			</snapshots>
-		</repository>
 	</repositories>
 	<distributionManagement>
 		<repository>
@@ -134,13 +119,6 @@
 	</reporting>
 	<dependencyManagement>
 		<dependencies>
-			<dependency>
-				<groupId>com.claymoresystems</groupId>
-				<artifactId>puretls</artifactId>
-				<version>1.1</version>
-				<scope>runtime</scope>
-				<type>jar</type>
-			</dependency>
 			<dependency>
 				<groupId>org.jglobus</groupId>
 				<artifactId>gss</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<spring.core.version>3.0.5.RELEASE</spring.core.version>
 		<spring.security.version>3.0.5.RELEASE</spring.security.version>
 		<hibernate.version>3.3.2.GA</hibernate.version>
-		<globus.version>1.8.0</globus.version>
+		<globus.version>2.0.6</globus.version>
 		<findbugs.version>2.5.2</findbugs.version>
 		<sl4j.version>1.6.6</sl4j.version> 
 		<log4j.version>1.2.16</log4j.version>
@@ -142,8 +142,8 @@
 				<type>jar</type>
 			</dependency>
 			<dependency>
-				<groupId>org.globus.jglobus</groupId>
-				<artifactId>cog-jglobus</artifactId>
+				<groupId>org.jglobus</groupId>
+				<artifactId>gss</artifactId>
 				<scope>compile</scope>
 				<version>${globus.version}</version>
 				<type>jar</type>


### PR DESCRIPTION
I think this addresses #226 (but I'm not sure it works because I cannot figure out how to run all of the tests-- are there network resources used in the tests that are not accessible outside of the consortium)?

Note that the jglobus libraries have not been released in a while, but these releases are at least newer than are currently used by jargon. Oh, and they are in mavenCentral, so I think this may remove the last need for the ci-dev.renci.org nexus repo for jargon.