### PR TITLE
rescHier (as resource hierarchy) instead of rescHeir

### DIFF
--- a/jargon-core/src/main/java/org/irods/jargon/core/packinstr/DataObjInfo.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/packinstr/DataObjInfo.java
@@ -21,7 +21,7 @@ public class DataObjInfo extends AbstractIRODSPackingInstruction {
 
 	private String objPath = "";
 	private String rescName = "";
-	private String rescHeir = "";
+	private String rescHier = "";
 	private String dataType = "";
 	private double dataSize = 0d;
 	private String checksum = "";
@@ -71,7 +71,7 @@ public class DataObjInfo extends AbstractIRODSPackingInstruction {
 	@Override
 	public Tag getTagValue() throws JargonException {
 		Tag message = new Tag(DataObjInfo.PI_TAG,
-				new Tag[] { new Tag("objPath", objPath), new Tag("rescName", rescName), new Tag("rescHeir", rescHeir),
+				new Tag[] { new Tag("objPath", objPath), new Tag("rescName", rescName), new Tag("rescHier", rescHier),
 						new Tag("dataType", dataType), new Tag("dataSize", dataSize), new Tag("chksum", checksum),
 						new Tag("version", version), new Tag("filePath", filePath),
 						new Tag("dataOwnerName", dataOwnerName), new Tag("dataOwnerZone", dataOwnerZone),
@@ -108,8 +108,8 @@ public class DataObjInfo extends AbstractIRODSPackingInstruction {
 		if (rescName != null) {
 			builder.append("rescName=").append(rescName).append(", ");
 		}
-		if (rescHeir != null) {
-			builder.append("rescHeir=").append(rescHeir).append(", ");
+		if (rescHier != null) {
+			builder.append("rescHier=").append(rescHier).append(", ");
 		}
 		if (dataType != null) {
 			builder.append("dataType=").append(dataType).append(", ");
@@ -191,12 +191,12 @@ public class DataObjInfo extends AbstractIRODSPackingInstruction {
 		this.rescName = rescName;
 	}
 
-	public String getRescHeir() {
-		return rescHeir;
+	public String getRescHier() {
+		return rescHier;
 	}
 
-	public void setRescHeir(String rescHeir) {
-		this.rescHeir = rescHeir;
+	public void setRescHier(String rescHier) {
+		this.rescHier = rescHier;
 	}
 
 	public String getDataType() {

--- a/jargon-core/src/main/java/org/irods/jargon/core/packinstr/SpecColInfo.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/packinstr/SpecColInfo.java
@@ -12,7 +12,7 @@ package org.irods.jargon.core.packinstr;
 public class SpecColInfo {
 
 	/**
-	 * Flag that indicates whether resource heirarchy is included in sending data to
+	 * Flag that indicates whether resource hierarchy is included in sending data to
 	 * iRODS, to accomodate protocol differences in 4.x
 	 */
 	private boolean useResourceHierarchy = false;

--- a/jargon-core/src/main/java/org/irods/jargon/core/packinstr/SpecColl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/packinstr/SpecColl.java
@@ -19,7 +19,7 @@ public class SpecColl extends AbstractIRODSPackingInstruction {
 	private String collection = "";
 	private String objPath = "";
 	private String resource = "";
-	private String rescHeir = "";
+	private String rescHier = "";
 	private String phyPath = "";
 	private String cacheDir = "";
 	private int cacheDirty = 0;
@@ -29,7 +29,7 @@ public class SpecColl extends AbstractIRODSPackingInstruction {
 	public static final String COLLECTION = "collection";
 	public static final String COLL_CLASS = "collClass";
 	public static final String RESOURCE = "resource";
-	public static final String RESC_HEIR = "rescHier";
+	public static final String RESC_HIER = "rescHier";
 	public static final String CACHE_DIR = "cacheDir";
 	public static final String CACHE_DIRTY = "cacheDirty";
 	public static final String REPL_NUM = "replNum";
@@ -59,7 +59,7 @@ public class SpecColl extends AbstractIRODSPackingInstruction {
 	public Tag getTagValue() throws JargonException {
 		Tag message = new Tag(PI_TAG, new Tag[] { new Tag(COLL_CLASS, getCollClass()),
 				new Tag(COLLECTION, getCollection()), new Tag(OBJ_PATH, getObjPath()), new Tag(RESOURCE, getResource()),
-				new Tag(RESC_HEIR, getRescHeir()), new Tag(PHY_PATH, getPhyPath()), new Tag(CACHE_DIR, getCacheDir()),
+				new Tag(RESC_HIER, getRescHier()), new Tag(PHY_PATH, getPhyPath()), new Tag(CACHE_DIR, getCacheDir()),
 				new Tag(CACHE_DIRTY, getCacheDirty()), new Tag(REPL_NUM, getReplNum()) });
 		return message;
 	}
@@ -104,12 +104,12 @@ public class SpecColl extends AbstractIRODSPackingInstruction {
 		this.resource = resource;
 	}
 
-	public String getRescHeir() {
-		return rescHeir;
+	public String getRescHier() {
+		return rescHier;
 	}
 
-	public void setRescHeir(final String rescHeir) {
-		this.rescHeir = rescHeir;
+	public void setRescHier(final String rescHier) {
+		this.rescHier = rescHier;
 	}
 
 	public String getPhyPath() {
@@ -157,8 +157,8 @@ public class SpecColl extends AbstractIRODSPackingInstruction {
 		if (resource != null) {
 			builder.append("resource=").append(resource).append(", ");
 		}
-		if (rescHeir != null) {
-			builder.append("rescHeir=").append(rescHeir).append(", ");
+		if (rescHier != null) {
+			builder.append("rescHier=").append(rescHier).append(", ");
 		}
 		if (phyPath != null) {
 			builder.append("phyPath=").append(phyPath).append(", ");

--- a/jargon-data-utils/INDEXING.md
+++ b/jargon-data-utils/INDEXING.md
@@ -59,7 +59,7 @@ public abstract class AbstractIrodsVisitorComponent extends AbstractJargonServic
 
 This pattern is used in the indexer package to create a visitor implementation that can support basic indexing operations. The AbstractIndexerVisitor component is
 a subclass of the AbstractIrodsVisitorComponent with the addition of metadata gathering. This specialized visitor will maintain a stack of AVU from the current location up the 
-heirarchy to the initial parent folder. This means that at each visit event all parent metadata is available. These can be accessed using the 'withMetadata' variants
+hierarchy to the initial parent folder. This means that at each visit event all parent metadata is available. These can be accessed using the 'withMetadata' variants
 of the visitor pattern, such as
 
 ```Java

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/visitor/HierComponent.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/visitor/HierComponent.java
@@ -6,7 +6,7 @@ package org.irods.jargon.datautils.visitor;
 import org.irods.jargon.core.exception.JargonException;
 
 /**
- * Interface for the 'Component' in the Heirarchical Visitor pattern. This is
+ * Interface for the 'Component' in the Hierarchical Visitor pattern. This is
  * the file or directory (leaf or composite) that is accessed by the crawler
  *
  * @author conwaymc


### PR DESCRIPTION
Correct a syntax error, spell rescH**ie**r (as resource hierarchy) instead of rescH**ei**r.

Make PI incorrect for SpecColl_PI and DataObjInfo_PI
Should correct #319