### PR TITLE
fixed StringIndexOutOfBoundsException and allowed quota values to be 0

### DIFF
--- a/jargon-core/src/main/java/org/irods/jargon/core/packinstr/GeneralAdminInp.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/packinstr/GeneralAdminInp.java
@@ -169,8 +169,8 @@ public class GeneralAdminInp extends AbstractIRODSPackingInstruction {
 			throw new IllegalArgumentException("null or empty userName");
 		}
 
-		if (quotaValue <= 0) {
-			throw new IllegalArgumentException("quota value is less than or equal to zero");
+		if (quotaValue < 0) {
+			throw new IllegalArgumentException("quota value is less than zero");
 		}
 
 		return new GeneralAdminInp("set-quota", "user", userName, "total", String.valueOf(quotaValue), BLANK, BLANK,

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/QuotaAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/QuotaAOImpl.java
@@ -106,7 +106,7 @@ public class QuotaAOImpl extends IRODSGenericAO implements QuotaAO {
 			throw new IllegalArgumentException("null or empty userName");
 		}
 
-		if (quotaValue <= 0) {
+		if (quotaValue < 0) {
 			throw new IllegalArgumentException("quotaValue is null or empty");
 		}
 

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/SimpleQueryExecutorAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/SimpleQueryExecutorAOImpl.java
@@ -231,6 +231,9 @@ public class SimpleQueryExecutorAOImpl extends IRODSGenericAO implements SimpleQ
 
 			for (int i = 1; i < rows.size(); i++) {
 				idx = rows.get(i).indexOf(':');
+				if(idx < 0) {
+					break;
+				}
 				thisCol = rows.get(i).substring(0, idx).trim();
 				if (thisCol.equals(firstColName)) {
 					break;


### PR DESCRIPTION
## 1. fixed StringIndexOutOfBoundsException
### I had StringIndexOutOfBoundsException using jargon
  
```
java.lang.StringIndexOutOfBoundsException: String index out of range: -1
```
rows were like below
```
[user_name: admin, zone_name: rdss, quota_limit: 1797045, quota_over: -1797045, modify_ts: 01630990563, , user_name: dyjbcswjorsy@test.idr, zone_name: rdss, quota_limit: 100, quota_over: -100, modify_ts: 01630980387]
```
  
after add "modify_ts" to **colNames** it should stop iterating as you intended, but since it tried to parse blank space before the second "user_name" it occurred Exception as it couldn't find ":" and called substring (0, -1).

It can be simply fixed by checking whether idx is a negative number or not. there could be more things to fix if you didn't intend any blank space but it would be a simple solution for this exception and won't have any side effect.


## 2. allowed quotaValue to be 0
![unnamed](https://user-images.githubusercontent.com/74809918/132473067-c5708f5b-9d4e-4e5f-8c78-0302115fc118.png)
I was looking for the way to remove Quota after they were allocated. 
Then I realized there is no way to remove them in Jargon so searched it on iRODS. as suq says allocating 0 value to quota means removing it and to use this function we need to allow it on jargon as well. 


ps. many thanks for keeping jargon great
