### PR TITLE
#391 fixed race condition around open and close

### DIFF
--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/ReplicaTokenCacheEntry.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/ReplicaTokenCacheEntry.java
@@ -3,9 +3,6 @@
  */
 package org.irods.jargon.core.connection;
 
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-
 /**
  * @author conwaymc
  *
@@ -28,12 +25,6 @@ public class ReplicaTokenCacheEntry {
 	 * Count of open files
 	 */
 	private int openCount = 0;
-
-	/**
-	 * a reentrant lock that will be used by the open and close methods for streams
-	 * that use replica tokens
-	 */
-	private final Lock lock = new ReentrantLock();
 
 	public ReplicaTokenCacheEntry(final String logicalPath) {
 
@@ -67,17 +58,13 @@ public class ReplicaTokenCacheEntry {
 	public void setOpenCount(int openCount) {
 		this.openCount = openCount;
 	}
-
-	public void incrementOpenCount() {
-		this.openCount = openCount + 1;
+	
+	public int incrementOpenCount() {
+		return ++openCount;
 	}
 
-	public void decrementOpenCount() {
-		this.openCount = openCount - 1;
-	}
-
-	public Lock getLock() {
-		return lock;
+	public int decrementOpenCount() {
+		return --openCount;
 	}
 
 	/**
@@ -107,11 +94,7 @@ public class ReplicaTokenCacheEntry {
 		if (replicaNumber != null) {
 			builder.append("replicaNumber=").append(replicaNumber).append(", ");
 		}
-		builder.append("openCount=").append(openCount).append(", ");
-		if (lock != null) {
-			builder.append("lock=").append(lock);
-		}
-		builder.append("]");
+		builder.append("openCount=").append(openCount).append("]");
 		return builder.toString();
 	}
 }

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/ReplicaTokenCacheManager.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/ReplicaTokenCacheManager.java
@@ -4,8 +4,11 @@
 package org.irods.jargon.core.connection;
 
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
+import org.irods.jargon.core.exception.JargonRuntimeException;
 import org.irods.jargon.core.exception.ReplicaTokenLockException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,20 +26,60 @@ import org.slf4j.LoggerFactory;
 public class ReplicaTokenCacheManager {
 
 	static Logger log = LoggerFactory.getLogger(ReplicaTokenCacheManager.class);
+	
+	public static class ReplicaTokenLock
+	{
+	    private final Lock lock = new ReentrantLock();
+	    private int refCount = 0;
+	    
+	    public void tryLock(int timeoutInSeconds, boolean incrementOnOpen)
+	    {
+            try {
+                if (!lock.tryLock(timeoutInSeconds, TimeUnit.SECONDS)) {
+                    log.error("timeout trying to lock replica token cache");
+                    throw new JargonRuntimeException("timeout obtaining replica token lock");
+                }
+                
+                if (incrementOnOpen) {
+                    ++refCount;
+                }
+            }
+            catch (InterruptedException e) {
+                log.info("interrupted", e);
+                throw new JargonRuntimeException("replica token cache tryLock interrupted", e);
+            }
+	    }
+	    
+	    public void unlock(boolean decrementOnClose)
+	    {
+	        if (decrementOnClose) {
+	            --refCount;
+	        }
+	        
+	        lock.unlock();
+	    }
+	    
+	    public int getRefCount()
+	    {
+	        return refCount;
+	    }
+	}
 
+	private ConcurrentHashMap<ReplicaTokenCacheKey, ReplicaTokenLock> replicaTokenLockCache = new ConcurrentHashMap<>();
 	private ConcurrentHashMap<ReplicaTokenCacheKey, ReplicaTokenCacheEntry> replicaTokenCache = new ConcurrentHashMap<>();
 
 	/**
-	 * Idempotent method to get a reference to a {@link Lock}. A valid lock must be
-	 * acquired before attempting to read, set, or clear a replica token entry
+	 * Idempotent method to get a reference to a {@code ReplicaTokenLock}. A valid
+	 * lock must be acquired before attempting to read, set, or clear a replica
+	 * token entry.
 	 *
 	 * @param logicalPath {@code String} which is the iRODS path which is protected
 	 *                    by the lock
 	 * @param userName    {@code String} which is hte user name
-	 * @return {@link Lock} object that can be tried in order to read or manipulate
-	 *         a replica token
+	 * @return {@code ReplicaTokenLock} object that can be tried in order to read or
+	 *                     manipulate a replica token
 	 */
-	public Lock obtainReplicaTokenLock(final String logicalPath, final String userName) {
+	public ReplicaTokenLock obtainReplicaTokenLock(final String logicalPath, final String userName) {
 
 		log.info("obtainReplicaTokenLock()");
 
@@ -46,33 +89,25 @@ public class ReplicaTokenCacheManager {
 
 		ReplicaTokenCacheKey cacheKey = ReplicaTokenCacheKey.instance(logicalPath, userName);
 
-		replicaTokenCache.putIfAbsent(cacheKey, new ReplicaTokenCacheEntry(logicalPath));
-		return replicaTokenCache.get(cacheKey).getLock();
+		return replicaTokenLockCache.computeIfAbsent(cacheKey, k -> new ReplicaTokenLock());
 
 	}
 
 	/**
-	 * After obtaining a lock, this should be the initial method called, it will
-	 * check if there is an existing replica token. If this method returns an empty
-	 * token, the calling initializer that is doing the open should call an open and
-	 * obtain the replica token from iRODS and then initialize the cache with that
-	 * token using the {@code addReplicaToken} method.
+	 * This method requires the caller to acquire the lock returned from
+	 * {@code obtainReplicaTokenLock}.
 	 * 
-	 * @param logicalPath {@code String} which is the iRODS path which is protected
-	 *                    by the lock
-	 * @param userName    {@code String} which is the user name
-	 * @return {@code ReplicaTokenCacheEntry} with the replica token string and
-	 *         replica number
+	 * Creates a new entry in the cache if (logicalPath, userName) are not mapped
+	 * to an existing entry.
 	 *
-	 * @throws ReplicaTokenLockException
+	 * @param logicalPath  {@code String} which is the iRODS path which is protected
+	 *                     by the lock
+	 * @param userName     {@code String} which is the user name
+	 * @return {@code ReplicaTokenCacheEntry} mapped to (logicalPath, userName)
 	 */
-	public ReplicaTokenCacheEntry claimExistingReplicaToken(final String logicalPath, final String userName)
-			throws ReplicaTokenLockException {
-		log.info("obtainExistingReplicaToken()");
+	public ReplicaTokenCacheEntry insertReplicaTokenEntry(final String logicalPath, final String userName) {
 
-		if (userName == null || userName.isEmpty()) {
-			throw new IllegalArgumentException("null or empty userName");
-		}
+		log.info("insertReplicaTokenEntry()");
 
 		if (logicalPath == null || logicalPath.isEmpty()) {
 			throw new IllegalArgumentException("null or empty logicalPath");
@@ -80,32 +115,18 @@ public class ReplicaTokenCacheManager {
 
 		ReplicaTokenCacheKey cacheKey = ReplicaTokenCacheKey.instance(logicalPath, userName);
 
-		ReplicaTokenCacheEntry replicaTokenCacheEntry = replicaTokenCache.get(cacheKey);
-		if (replicaTokenCacheEntry == null) {
-			log.error("no cache entry found, perhaps lock was not acquired?");
-			throw new ReplicaTokenLockException("null cache entry, was lock acquired before calling this method?");
-		}
-
-		/*
-		 * If this replica token is already acquired, increment the count
-		 */
-
-		if (!replicaTokenCacheEntry.getReplicaToken().isEmpty()) {
-			replicaTokenCacheEntry.incrementOpenCount();
-		}
-
-		return replicaTokenCacheEntry;
+        return (ReplicaTokenCacheEntry) replicaTokenCache
+            .computeIfAbsent(cacheKey, k -> new ReplicaTokenCacheEntry(logicalPath));
 
 	}
 
 	/**
-	 * This method requires the caller to first call {@code obtainReplicaTokenLock}
-	 * with a {@code tryLock()} before updating with a valid replica token. This
-	 * method is called when the open is the first open for a file. On this first
-	 * open a call is made to obtain a replica token which will then be added to the
-	 * cache via the {@code addReplicaToken()} method.
-	 *
-	 * This method is used
+	 * This method requires the caller to acquire the lock returned from
+	 * {@code obtainReplicaTokenLock} before updating with a valid replica token.
+	 * 
+	 * This method is called when the open is the first open for a file. On this
+	 * first open, a call is made to obtain a replica token which will then be
+	 * added to the cache via the {@code addReplicaToken()} method.
 	 *
 	 * @param logicalPath  {@code String} which is the iRODS path which is protected
 	 *                     by the lock
@@ -145,7 +166,6 @@ public class ReplicaTokenCacheManager {
 		if (!replicaTokenCacheEntry.getReplicaToken().isEmpty()) {
 			log.error("A token already exists, was lock called?");
 			throw new ReplicaTokenLockException("A token already exists, was lock called?");
-
 		}
 
 		replicaTokenCacheEntry.setReplicaToken(replicaToken);
@@ -155,26 +175,22 @@ public class ReplicaTokenCacheManager {
 	}
 
 	/**
-	 * This method requires the caller to first call {@code obtainReplicaTokenLock}
-	 * with a {@code tryLock()}.
-	 *
+	 * This method requires the caller to acquire the lock returned from
+	 * {@code obtainReplicaTokenLock}.
 	 *
 	 * This method is called when a file is being closed, and where a replica token
-	 * was obtained. This method will decrement the count, when it gets to zero all
-	 * file handles are closed and the cache entry is removed. It is up to the
-	 * caller to adjust the close parameters to update the catalog, compute
-	 * checksums, and carry out all iRODS close operations with the desired close
-	 * flags.
+	 * was obtained. This method will decrement the open count and report whether
+	 * it is the final stream associated with the replica token.
 	 *
 	 * @param logicalPath {@code String} with the logical path to the file to be
-	 *                    closed * @param userName {@code String} which is the user
-	 *                    name
+	 *                    closed
+	 * @param userName    {@code String} which is the user name
 	 * @return {@code boolean} with a value of {@code true} when this is the last
 	 *         reference to the file
 	 */
-	public boolean closeReplicaToken(final String logicalPath, final String userName) {
+	public boolean isFinalReferenceToReplicaToken(final String logicalPath, final String userName) {
 
-		log.info("closeReplicaToken()");
+		log.info("isFinalReferenceToReplicaToken()");
 
 		if (logicalPath == null || logicalPath.isEmpty()) {
 			throw new IllegalArgumentException("null or empty logicalPath");
@@ -188,18 +204,49 @@ public class ReplicaTokenCacheManager {
 		log.info("userName:{}", userName);
 
 		ReplicaTokenCacheKey cacheKey = ReplicaTokenCacheKey.instance(logicalPath, userName);
+		ReplicaTokenCacheEntry cacheEntry = replicaTokenCache.get(cacheKey);
 
-		ReplicaTokenCacheEntry replicaTokenCacheEntry = replicaTokenCache.get(cacheKey);
-		replicaTokenCacheEntry.decrementOpenCount();
-		if (replicaTokenCacheEntry.getOpenCount() < 0) {
-			log.error("replica count less than zero, this is an unexpected condition that indicates a system problem");
-			throw new IllegalStateException("replica count should never be less than zero");
-		} else if (replicaTokenCacheEntry.getOpenCount() == 0) {
-			replicaTokenCache.remove(cacheKey);
-			return true;
-		} else {
-			return false;
+		return cacheEntry.getOpenCount() == 1;
+
+	}
+
+	/**
+	 * This method requires the caller to acquire the lock returned from
+	 * {@code obtainReplicaTokenLock}.
+	 *
+	 * This method is called when a file is being closed, and where a replica token
+	 * was obtained. This method will remove the cache entry when the open count
+	 * becomes zero.
+	 *
+	 * @param logicalPath {@code String} with the logical path to the file to be
+	 *                    closed
+	 * @param userName    {@code String} which is the user name
+	 */
+	public void removeReplicaToken(final String logicalPath, final String userName) {
+
+		log.info("removeReplicaToken()");
+
+		if (logicalPath == null || logicalPath.isEmpty()) {
+			throw new IllegalArgumentException("null or empty logicalPath");
 		}
+
+		if (userName == null || userName.isEmpty()) {
+			throw new IllegalArgumentException("null or empty userName");
+		}
+
+		log.info("logicalPath:{}", logicalPath);
+		log.info("userName:{}", userName);
+
+		ReplicaTokenCacheKey cacheKey = ReplicaTokenCacheKey.instance(logicalPath, userName);
+		
+        ReplicaTokenCacheEntry replicaTokenCacheEntry = replicaTokenCache.get(cacheKey);
+
+        if (replicaTokenCacheEntry.decrementOpenCount() == 0) {
+            replicaTokenCache.remove(cacheKey);
+        }
+        else if (replicaTokenCacheEntry.getOpenCount() < 0){
+            log.error("replica count less than zero, this is an unexpected condition that indicates a system problem");
+        }
 
 	}
 

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/io/IRODSFile.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/io/IRODSFile.java
@@ -359,11 +359,11 @@ public interface IRODSFile {
 	String getReplicaToken();
 
 	/**
-	 * Set the resource token if one is available (dependant on iRODS version)
+	 * Set the replica token if one is available (dependant on iRODS version)
 	 * 
-	 * @param resourceToken {@code String} with the resource token value, if
+	 * @param replicaToken {@code String} with the replica token value, if
 	 *                      available
 	 */
-	void setReplicaToken(String resourceToken);
+	void setReplicaToken(String replicaToken);
 
 }


### PR DESCRIPTION
@michael-conway Please take a moment to look over this code before merging it.

My original fix I discussed with you earlier exposed another issue that this PR resolves.

After moving the handling of cache entry removal out of `closeReplicaToken()`, I discovered that the call to `claimExistingReplicaToken()` was throwing an exception because the cache entry didn't exist anymore. This can happen when `obtainReplicaTokenLock()` is called by one thread and another thread, operating on the same replica, removes the cache entry owning the lock returned by `obtainReplicaTokenLock()`.

This PR addresses this situation by introducing an atomic reference counter. The counter tracks how many threads have obtained, but not acquired, a lock for a particular cache entry. With that, we only allow removal of the cache entry if the atomic reference counter reaches zero.