### PR TITLE
 exclude log4j:1.2.14 from jglobus

### DIFF
--- a/jargon-core/pom.xml
+++ b/jargon-core/pom.xml
@@ -35,6 +35,10 @@
 					<artifactId>jce</artifactId>
 					<groupId>org.bouncycastle</groupId>
 				</exclusion>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/74809918/158333436-a06cf9a3-f1a3-4f5b-9320-b5b1f004905a.png)
> jglobus contains log4j:1.2.14 which is vulnerable