### PR TITLE
Pinned docker test framework for 4.2 to Ubuntu 18 and 4.2.12

### DIFF
--- a/docker-test-framework/4-2/Dockerfile.consumer
+++ b/docker-test-framework/4-2/Dockerfile.consumer
@@ -1,18 +1,18 @@
 #
 # iRODS Consumer Image.
 #
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # TODO: Remove this line when apt gets its stuff together
-RUN sed --in-place --regexp-extended "s/(\/\/)(archive\.ubuntu)/\1nl.\2/" /etc/apt/sources.list
+#RUN sed --in-place --regexp-extended "s/(\/\/)(archive\.ubuntu)/\1nl.\2/" /etc/apt/sources.list
 
 RUN apt-get update && \
-    apt-get install -y sudo wget less lsb-release apt-transport-https netcat
+    apt-get install -y sudo wget less lsb-release apt-transport-https netcat gnupg2
 
 RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add -; \
     echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list; \
     apt-get update && \
-    apt-get install -y irods-runtime irods-icommands irods-server
+    apt-get install -y irods-runtime=4.2.12-1~bionic irods-icommands=4.2.12-1~bionic irods-server=4.2.12-1~bionic
 
 EXPOSE 1247 1248
 

--- a/docker-test-framework/4-2/Dockerfile.provider
+++ b/docker-test-framework/4-2/Dockerfile.provider
@@ -1,14 +1,16 @@
 #
 # iRODS Provider Image.
 #
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # TODO: Remove this line when apt gets its stuff together
-RUN sed --in-place --regexp-extended "s/(\/\/)(archive\.ubuntu)/\1nl.\2/" /etc/apt/sources.list
+#RUN sed --in-place --regexp-extended "s/(\/\/)(archive\.ubuntu)/\1nl.\2/" /etc/apt/sources.list
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install pre-requisites
 RUN apt-get update && \
-    apt-get install -y sudo wget lsb-release apt-transport-https postgresql vim python-pip libfuse2 unixodbc rsyslog less && \
+    apt-get install -y sudo wget lsb-release apt-transport-https postgresql vim python-pip libfuse2 unixodbc rsyslog less gnupg2 && \
     pip install xmlrunner
 
 # Setup catalog database
@@ -18,7 +20,7 @@ RUN service postgresql start && su - postgres -c 'psql -f /db_commands.txt'
 RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add -; \
     echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list; \
     apt-get update && \
-    apt-get install -y irods-runtime irods-icommands irods-server irods-database-plugin-postgres
+    apt-get install -y irods-runtime=4.2.12-1~bionic irods-icommands=4.2.12-1~bionic irods-server=4.2.12-1~bionic irods-database-plugin-postgres=4.2.12-1~bionic
 
 EXPOSE 1247 1248
 
@@ -30,5 +32,3 @@ ADD testsetup-consortium.sh /
 RUN chmod +x /testsetup-consortium.sh
 RUN chmod u+x /start_provider.sh
 ENTRYPOINT ["./start_provider.sh"]
-
-

--- a/docker-test-framework/4-2/Dockerfile.testbuild
+++ b/docker-test-framework/4-2/Dockerfile.testbuild
@@ -6,6 +6,4 @@ FROM maven:3.6.3-jdk-11
 RUN apt-get update && \
     apt-get install -y sudo wget nano
 
-
-
 CMD tail -f /dev/null

--- a/jargon-core/src/test/java/org/irods/jargon/core/pub/io/IRODSFileOutputStreamTest.java
+++ b/jargon-core/src/test/java/org/irods/jargon/core/pub/io/IRODSFileOutputStreamTest.java
@@ -263,7 +263,6 @@ public class IRODSFileOutputStreamTest {
 		IRODSFileFactory irodsFileFactory = accessObjectFactory.getIRODSFileFactory(irodsAccount);
 
 		IRODSFile irodsFile = irodsFileFactory.instanceIRODSFile(targetIrodsCollection + '/' + testFileName);
-		irodsFile.setResource("repl");// resource set?
 		IRODSFileOutputStream irodsFileOutputStream = irodsFileFactory.instanceIRODSFileOutputStream(irodsFile);
 
 		int writtenInt = 3;


### PR DESCRIPTION
This PR updates the 4-2 docker test framework so that 4.2.12 is used for testing.

This PR was used to test #423. Out of the 1500+ jargon-core tests, only one failed with an error. Output below.
```bash
[ERROR] Tests run: 1558, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 2,280.877 s <<< FAILURE! - in org.irods.jargon.core.unittest.AllTests
[ERROR] testWriteInt(org.irods.jargon.core.pub.io.IRODSFileOutputStreamTest)  Time elapsed: 0.074 s  <<< ERROR!
org.irods.jargon.core.exception.ResourceDoesNotExistException: SYS_RESC_DOES_NOT_EXIST
        at org.irods.jargon.core.pub.io.IRODSFileOutputStreamTest.testWriteInt(IRODSFileOutputStreamTest.java:267)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   IRODSFileOutputStreamTest.testWriteInt:267 » ResourceDoesNotExist SYS_RESC_DOE...
[INFO] 
[ERROR] Tests run: 1558, Failures: 0, Errors: 1, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Jargon 4.3.3.0-RELEASE:
[INFO] 
[INFO] Jargon ............................................. SUCCESS [  2.180 s]
[INFO] Jargon Core ........................................ FAILURE [39:34 min]
[INFO] Jargon User Tagging ................................ SKIPPED
[INFO] Jargon Data Utils .................................. SKIPPED
[INFO] Jargon Ticket ...................................... SKIPPED
[INFO] Jargon Pool ........................................ SKIPPED
[INFO] Jargon Rule Service ................................ SKIPPED
[INFO] data-profile ....................................... SKIPPED
[INFO] jargon-zipservice .................................. SKIPPED
[INFO] Jargon Metadata Query .............................. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  39:38 min
[INFO] Finished at: 2023-08-06T22:57:13Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.1:test (default-test) on project jargon-core: There are test failures.
[ERROR] 
[ERROR] Please refer to /usr/src/jargon/jargon-core/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :jargon-core
```

Given the results, I think PR #423 is safe for merging. I also think this PR is safe for merging.