### PR TITLE
[451,484] Update log4j dependency to 2.x (master)

### DIFF
--- a/data-profile/src/main/java/org/irods/jargon/dataprofile/DataProfileServiceImpl.java
+++ b/data-profile/src/main/java/org/irods/jargon/dataprofile/DataProfileServiceImpl.java
@@ -23,8 +23,8 @@ import org.irods.jargon.core.utils.CollectionAndPath;
 import org.irods.jargon.core.utils.MiscIRODSUtils;
 import org.irods.jargon.usertagging.domain.IRODSTagValue;
 import org.irods.jargon.usertagging.tags.UserTaggingConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Service that will gather data associated with a Data Object or Collection
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DataProfileServiceImpl extends AbstractJargonService implements DataProfileService {
 
-	public static final Logger log = LoggerFactory.getLogger(DataProfileServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(DataProfileServiceImpl.class);
 
 	private final DataTypeResolutionService dataTypeResolutionService;
 

--- a/data-profile/src/main/java/org/irods/jargon/dataprofile/DataTypeResolutionServiceImpl.java
+++ b/data-profile/src/main/java/org/irods/jargon/dataprofile/DataTypeResolutionServiceImpl.java
@@ -19,8 +19,8 @@ import org.irods.jargon.core.query.MetaDataAndDomainData;
 import org.irods.jargon.core.service.AbstractJargonService;
 import org.irods.jargon.core.utils.LocalFileUtils;
 import org.irods.jargon.usertagging.tags.UserTaggingConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Service to identify the data type of an iRODS file based on a series of
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 public class DataTypeResolutionServiceImpl extends AbstractJargonService implements DataTypeResolutionService {
 
 	public static final String APPLICATION_IRODS_RULE = "application/irods-rule";
-	public static final Logger log = LoggerFactory.getLogger(DataTypeResolutionServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(DataTypeResolutionServiceImpl.class);
 
 	@Override
 	public String resolveDataTypeWithProvidedAvuAndDataObject(final DataObject dataObject,

--- a/jargon-core/src/main/java/org/irods/jargon/core/checksum/ChecksumManagerImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/checksum/ChecksumManagerImpl.java
@@ -6,6 +6,8 @@ package org.irods.jargon.core.checksum;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.irods.jargon.core.connection.DiscoveredServerPropertiesCache;
 import org.irods.jargon.core.connection.IRODSAccount;
 import org.irods.jargon.core.connection.IRODSServerProperties;
@@ -15,8 +17,6 @@ import org.irods.jargon.core.protovalues.ChecksumEncodingEnum;
 import org.irods.jargon.core.pub.DataObjectAO;
 import org.irods.jargon.core.pub.EnvironmentalInfoAO;
 import org.irods.jargon.core.pub.IRODSAccessObjectFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Various methods to compute and determine checksums
@@ -33,7 +33,7 @@ public class ChecksumManagerImpl implements ChecksumManager {
 	private final IRODSAccount irodsAccount;
 	private final IRODSAccessObjectFactory irodsAccessObjectFactory;
 
-	public static final Logger log = LoggerFactory.getLogger(ChecksumManagerImpl.class);
+	public static final Logger log = LogManager.getLogger(ChecksumManagerImpl.class);
 
 	/**
 	 * @param irodsAccount

--- a/jargon-core/src/main/java/org/irods/jargon/core/checksum/MD5LocalChecksumComputerStrategy.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/checksum/MD5LocalChecksumComputerStrategy.java
@@ -7,11 +7,11 @@ import java.io.FileNotFoundException;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.protovalues.ChecksumEncodingEnum;
 import org.irods.jargon.core.utils.LocalFileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Compute an MD5 checksum on a local file
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MD5LocalChecksumComputerStrategy extends AbstractChecksumComputeStrategy {
 
-	public static final Logger log = LoggerFactory.getLogger(MD5LocalChecksumComputerStrategy.class);
+	public static final Logger log = LogManager.getLogger(MD5LocalChecksumComputerStrategy.class);
 
 	/*
 	 * (non-Javadoc)

--- a/jargon-core/src/main/java/org/irods/jargon/core/checksum/SHA256LocalChecksumComputerStrategy.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/checksum/SHA256LocalChecksumComputerStrategy.java
@@ -7,11 +7,11 @@ import java.io.FileNotFoundException;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.protovalues.ChecksumEncodingEnum;
 import org.irods.jargon.core.utils.LocalFileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Compute an SHA256 checksum on a local file
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SHA256LocalChecksumComputerStrategy extends AbstractChecksumComputeStrategy {
 
-	public static final Logger log = LoggerFactory.getLogger(SHA256LocalChecksumComputerStrategy.class);
+	public static final Logger log = LogManager.getLogger(SHA256LocalChecksumComputerStrategy.class);
 
 	/*
 	 * (non-Javadoc)

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/AbstractConnection.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/AbstractConnection.java
@@ -13,8 +13,8 @@ import java.nio.channels.ClosedChannelException;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.utils.Host;
 import org.irods.jargon.core.utils.LocalFileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Abstract connection to iRODS, representing the network layer of communication
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractConnection {
 
-	static final Logger log = LoggerFactory.getLogger(AbstractConnection.class);
+	static final Logger log = LogManager.getLogger(AbstractConnection.class);
 
 	protected IRODSProtocolManager irodsProtocolManager;
 	private String connectionInternalIdentifier;

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/AbstractIRODSMidLevelProtocolFactory.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/AbstractIRODSMidLevelProtocolFactory.java
@@ -5,8 +5,8 @@ package org.irods.jargon.core.connection;
 
 import org.irods.jargon.core.exception.AuthenticationException;
 import org.irods.jargon.core.exception.JargonException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Factory for creating the {@code AbstractIRODSMidLevelProtocol} object that
@@ -28,7 +28,7 @@ abstract class AbstractIRODSMidLevelProtocolFactory {
 	private final IRODSConnectionFactory irodsConnectionFactory;
 	private final AuthenticationFactory authenticationFactory;
 
-	Logger log = LoggerFactory.getLogger(AbstractIRODSMidLevelProtocolFactory.class);
+	Logger log = LogManager.getLogger(AbstractIRODSMidLevelProtocolFactory.class);
 
 	/**
 	 * Create the factory that will produced connected 'mid level protocol

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/AuthMechanism.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/AuthMechanism.java
@@ -13,8 +13,8 @@ import org.irods.jargon.core.packinstr.ClientServerNegotiationStructInitNegotiat
 import org.irods.jargon.core.packinstr.StartupPack;
 import org.irods.jargon.core.packinstr.Tag;
 import org.irods.jargon.core.protovalues.RequestTypes;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Represents a type of authentication scheme, outlining a life cycle model of
@@ -32,7 +32,7 @@ abstract class AuthMechanism {
 
 	public String cachedChallenge = "";
 
-	public static final Logger log = LoggerFactory.getLogger(AuthMechanism.class);
+	public static final Logger log = LogManager.getLogger(AuthMechanism.class);
 
 	/**
 	 * Optional method that will be called before any startup pack is sent

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/AuthenticationFactoryImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/AuthenticationFactoryImpl.java
@@ -2,8 +2,8 @@ package org.irods.jargon.core.connection;
 
 import org.irods.jargon.core.connection.auth.AuthUnavailableException;
 import org.irods.jargon.core.exception.JargonException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * An implementation of a factory that can create an implementation of
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AuthenticationFactoryImpl implements AuthenticationFactory {
 
-	private Logger log = LoggerFactory.getLogger(AuthenticationFactoryImpl.class);
+	private Logger log = LogManager.getLogger(AuthenticationFactoryImpl.class);
 
 	@Override
 	public AuthMechanism instanceAuthMechanism(final IRODSAccount irodsAccount)

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/ClientServerNegotiationPolicy.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/ClientServerNegotiationPolicy.java
@@ -3,8 +3,8 @@
  */
 package org.irods.jargon.core.connection;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Captures the client-server negotiation policy for iRODS. This can be tuned
@@ -24,7 +24,7 @@ public class ClientServerNegotiationPolicy {
 	 * interpolate with the negotiation table.
 	 */
 
-	private static Logger log = LoggerFactory.getLogger(ClientServerNegotiationPolicy.class);
+	private static Logger log = LogManager.getLogger(ClientServerNegotiationPolicy.class);
 
 	public enum SslNegotiationPolicy {
 		CS_NEG_REQUIRE, CS_NEG_DONT_CARE, CS_NEG_REFUSE, NO_NEGOTIATION, CS_NEG_FAILURE

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/ClientServerNegotiationService.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/ClientServerNegotiationService.java
@@ -15,8 +15,8 @@ import org.irods.jargon.core.packinstr.Tag;
 import org.irods.jargon.core.protovalues.EncryptionAlgorithmEnum;
 import org.irods.jargon.core.transfer.encrypt.AESKeyGenerator;
 import org.irods.jargon.core.transfer.encrypt.AbstractKeyGenerator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Captures the client/server negotiation process in the client given a
@@ -29,7 +29,7 @@ class ClientServerNegotiationService {
 
 	private final IRODSMidLevelProtocol irodsMidLevelProtocol;
 
-	private Logger log = LoggerFactory.getLogger(ClientServerNegotiationService.class);
+	private Logger log = LogManager.getLogger(ClientServerNegotiationService.class);
 	public static final String NEGOTIATION_SHARED_SECRET = "SHARED_SECRET";
 
 	/*

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/DiscoveredServerPropertiesCache.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/DiscoveredServerPropertiesCache.java
@@ -7,8 +7,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.irods.jargon.core.pub.domain.ClientHints;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Somewhat experimental cache of discovered properties, these are aspects of
@@ -43,7 +43,7 @@ public class DiscoveredServerPropertiesCache {
 	private ConcurrentHashMap<String, ClientHints> cacheOfClientHints = new ConcurrentHashMap<String, ClientHints>(8,
 			0.9f, 1);
 
-	public static final Logger log = LoggerFactory.getLogger(DiscoveredServerPropertiesCache.class);
+	public static final Logger log = LogManager.getLogger(DiscoveredServerPropertiesCache.class);
 
 	/*
 	 * basic properties that can be cached

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/EnvironmentalInfoAccessor.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/EnvironmentalInfoAccessor.java
@@ -7,8 +7,8 @@ import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.packinstr.MiscSvrInfo;
 import org.irods.jargon.core.packinstr.Tag;
 import org.irods.jargon.core.utils.IRODSConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Obtain information about the connected irods server.
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 public class EnvironmentalInfoAccessor {
 
 	private IRODSMidLevelProtocol irodsProtocol = null;
-	private final Logger log = LoggerFactory.getLogger(EnvironmentalInfoAccessor.class);
+	private final Logger log = LogManager.getLogger(EnvironmentalInfoAccessor.class);
 
 	public EnvironmentalInfoAccessor(final IRODSMidLevelProtocol irodsProtocol) throws JargonException {
 		if (irodsProtocol == null) {

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/GSIAuth.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/GSIAuth.java
@@ -15,8 +15,8 @@ import org.irods.jargon.core.exception.AuthenticationException;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.exception.JargonRuntimeException;
 import org.irods.jargon.core.protovalues.RequestTypes;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Support for Globus GSI authentication for iRODS
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  */
 class GSIAuth extends AuthMechanism {
 
-	public static final Logger log = LoggerFactory.getLogger(GSIAuth.class);
+	public static final Logger log = LogManager.getLogger(GSIAuth.class);
 	private static final int GSI_AUTH_REQUEST_AN = 711;
 
 	/**

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/IRODSBasicTCPConnection.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/IRODSBasicTCPConnection.java
@@ -10,8 +10,8 @@ import java.net.UnknownHostException;
 import javax.net.ssl.SSLSocket;
 
 import org.irods.jargon.core.exception.JargonException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Wraps a connection to the iRODS server described by the given IRODSAccount.
@@ -51,7 +51,7 @@ class IRODSBasicTCPConnection extends AbstractConnection {
 		super(irodsAccount, pipelineConfiguration, irodsProtocolManager, irodsSession);
 	}
 
-	static final Logger log = LoggerFactory.getLogger(IRODSBasicTCPConnection.class);
+	static final Logger log = LogManager.getLogger(IRODSBasicTCPConnection.class);
 
 	/**
 	 * Default constructor that gives the account and pipeline setup information.

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/IRODSErrorScanner.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/IRODSErrorScanner.java
@@ -36,8 +36,8 @@ import org.irods.jargon.core.exception.UnixFileMkdirException;
 import org.irods.jargon.core.exception.UnixFileRenameException;
 import org.irods.jargon.core.exception.ZoneUnavailableException;
 import org.irods.jargon.core.protovalues.ErrorEnum;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * This object is interposed in the process of interpreting the iRODS responses
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  */
 public class IRODSErrorScanner {
 
-	public static final Logger log = LoggerFactory.getLogger(IRODSErrorScanner.class);
+	public static final Logger log = LogManager.getLogger(IRODSErrorScanner.class);
 
 	/**
 	 * Scan the response for errors, and incorporate any message information that

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/IRODSMidLevelProtocol.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/IRODSMidLevelProtocol.java
@@ -21,8 +21,8 @@ import org.irods.jargon.core.protovalues.ErrorEnum;
 import org.irods.jargon.core.protovalues.RequestTypes;
 import org.irods.jargon.core.pub.PluggableApiCallResult;
 import org.irods.jargon.core.utils.IRODSConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Encapsulates sending of messages and parsing of responses above the socket
@@ -80,7 +80,7 @@ import org.slf4j.LoggerFactory;
  */
 public class IRODSMidLevelProtocol {
 
-	Logger log = LoggerFactory.getLogger(IRODSMidLevelProtocol.class);
+	Logger log = LogManager.getLogger(IRODSMidLevelProtocol.class);
 
 	private AbstractConnection irodsConnection;
 	private AbstractConnection irodsConnectionNonEncryptedRef = null;

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/IRODSProtocolManager.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/IRODSProtocolManager.java
@@ -2,8 +2,8 @@ package org.irods.jargon.core.connection;
 
 import org.irods.jargon.core.exception.AuthenticationException;
 import org.irods.jargon.core.exception.JargonException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public abstract class IRODSProtocolManager {
 
@@ -21,7 +21,7 @@ public abstract class IRODSProtocolManager {
 
 	private AbstractIRODSMidLevelProtocolFactory irodsMidLevelProtocolFactory;
 
-	private Logger log = LoggerFactory.getLogger(IRODSProtocolManager.class);
+	private Logger log = LogManager.getLogger(IRODSProtocolManager.class);
 
 	/**
 	 * Get the factory object that will create various authentication methods on

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/IRODSSession.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/IRODSSession.java
@@ -42,8 +42,8 @@ import org.irods.jargon.core.transfer.DefaultTransferControlBlock;
 import org.irods.jargon.core.transfer.MemoryBasedTransferRestartManager;
 import org.irods.jargon.core.transfer.TransferControlBlock;
 import org.irods.jargon.core.utils.MiscIRODSUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -123,7 +123,7 @@ public class IRODSSession {
 	 */
 	private ExecutorService parallelTransferThreadPool = null;
 	private IRODSProtocolManager irodsProtocolManager;
-	private static final Logger log = LoggerFactory.getLogger(IRODSSession.class);
+	private static final Logger log = LogManager.getLogger(IRODSSession.class);
 
 	/**
 	 * Trust manager (which can have a custom manager injected) for SSL

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/IRODSSimpleProtocolManager.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/IRODSSimpleProtocolManager.java
@@ -2,8 +2,8 @@ package org.irods.jargon.core.connection;
 
 import org.irods.jargon.core.exception.AuthenticationException;
 import org.irods.jargon.core.exception.JargonException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * This connection manager simply returns a stand-alone connection to IRODS.
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class IRODSSimpleProtocolManager extends IRODSProtocolManager {
 
-	private Logger log = LoggerFactory.getLogger(IRODSSimpleProtocolManager.class);
+	private Logger log = LogManager.getLogger(IRODSSimpleProtocolManager.class);
 
 	public static IRODSSimpleProtocolManager instance() {
 		return new IRODSSimpleProtocolManager();

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/IRODSTCPConnectionFactoryImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/IRODSTCPConnectionFactoryImpl.java
@@ -4,8 +4,8 @@
 package org.irods.jargon.core.connection;
 
 import org.irods.jargon.core.exception.JargonException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Implementation of a connection factory for producing the default TCP/IP
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
  */
 class IRODSTCPConnectionFactoryImpl extends IRODSConnectionFactory {
 
-	private static final Logger log = LoggerFactory.getLogger(IRODSTCPConnectionFactoryImpl.class);
+	private static final Logger log = LogManager.getLogger(IRODSTCPConnectionFactoryImpl.class);
 
 	@Override
 	protected AbstractConnection instance(final IRODSAccount irodsAccount, final IRODSSession irodsSession,

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/PAMAuth.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/PAMAuth.java
@@ -13,8 +13,8 @@ import org.irods.jargon.core.packinstr.AuthReqPluginRequestInp;
 import org.irods.jargon.core.packinstr.PamAuthRequestInp;
 import org.irods.jargon.core.packinstr.Tag;
 import org.irods.jargon.core.utils.MiscIRODSUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Support for PAM (plug-able authentication module) contributed by Chris Smith
@@ -30,7 +30,7 @@ public class PAMAuth extends AuthMechanism {
 
 	private boolean needToWrapWithSsl = false;
 
-	public static final Logger log = LoggerFactory.getLogger(PAMAuth.class);
+	public static final Logger log = LogManager.getLogger(PAMAuth.class);
 
 	@Override
 	protected IRODSMidLevelProtocol processAuthenticationAfterStartup(final IRODSAccount irodsAccount,

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/RejectedParallelThreadExecutionHandler.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/RejectedParallelThreadExecutionHandler.java
@@ -4,8 +4,8 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Handler for rejected executions of parallel threads
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RejectedParallelThreadExecutionHandler implements RejectedExecutionHandler {
 
-	public static final Logger log = LoggerFactory.getLogger(RejectedParallelThreadExecutionHandler.class);
+	public static final Logger log = LogManager.getLogger(RejectedParallelThreadExecutionHandler.class);
 
 	/**
 	 *

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/ReplicaTokenCacheManager.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/ReplicaTokenCacheManager.java
@@ -12,8 +12,8 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.irods.jargon.core.exception.JargonRuntimeException;
 import org.irods.jargon.core.exception.ReplicaTokenLockException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * @author conwaymc
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ReplicaTokenCacheManager {
 
-	static Logger log = LoggerFactory.getLogger(ReplicaTokenCacheManager.class);
+	static Logger log = LogManager.getLogger(ReplicaTokenCacheManager.class);
 
 	private Map<String, ReferenceCountedLockMap> replicaTokenLockCache = new ConcurrentHashMap<>();
 	private Map<ReplicaTokenCacheKey, ReplicaTokenCacheEntry> replicaTokenCache = new ConcurrentHashMap<>();

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/SslConnectionUtilities.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/SslConnectionUtilities.java
@@ -21,8 +21,8 @@ import javax.net.ssl.TrustManager;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.exception.JargonRuntimeException;
 import org.irods.jargon.core.packinstr.SSLStartInp;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Utilities to generate SSL connections for PAM and for general TLS support
@@ -35,7 +35,7 @@ class SslConnectionUtilities {
 	@SuppressWarnings("unused")
 	private final IRODSSession irodsSession;
 
-	private Logger log = LoggerFactory.getLogger(SslConnectionUtilities.class);
+	private Logger log = LogManager.getLogger(SslConnectionUtilities.class);
 
 	SslConnectionUtilities(final IRODSSession irodsSession) {
 		super();

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/StandardIRODSAuth.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/StandardIRODSAuth.java
@@ -11,8 +11,8 @@ import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.packinstr.AuthResponseInp;
 import org.irods.jargon.core.utils.Base64;
 import org.irods.jargon.core.utils.IRODSConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Standard iRODS challange/response mechanism
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  */
 public class StandardIRODSAuth extends AuthMechanism {
 
-	public static final Logger log = LoggerFactory.getLogger(StandardIRODSAuth.class);
+	public static final Logger log = LogManager.getLogger(StandardIRODSAuth.class);
 
 	/**
 	 * Do the normal iRODS password challenge/response sequence

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/TrustAllX509TrustManager.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/TrustAllX509TrustManager.java
@@ -4,8 +4,8 @@ import java.security.cert.X509Certificate;
 
 import javax.net.ssl.X509TrustManager;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * DO NOT USE IN PRODUCTION!!!!
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TrustAllX509TrustManager implements X509TrustManager {
 
-	private static final Logger log = LoggerFactory.getLogger(TrustAllX509TrustManager.class);
+	private static final Logger log = LogManager.getLogger(TrustAllX509TrustManager.class);
 
 	@Override
 	public X509Certificate[] getAcceptedIssuers() {

--- a/jargon-core/src/main/java/org/irods/jargon/core/packinstr/AbstractIRODSPackingInstruction.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/packinstr/AbstractIRODSPackingInstruction.java
@@ -6,8 +6,8 @@ package org.irods.jargon.core.packinstr;
 import java.util.List;
 
 import org.irods.jargon.core.exception.JargonException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Generic representation of a packing instruction for the IRODS XML Protocol
@@ -32,7 +32,7 @@ public abstract class AbstractIRODSPackingInstruction implements IRodsPI {
 	public static final String INX = "inx";
 	private int apiNumber = 0;
 
-	private final Logger log = LoggerFactory.getLogger(this.getClass());
+	private final Logger log = LogManager.getLogger(this.getClass());
 
 	public AbstractIRODSPackingInstruction() {
 	}

--- a/jargon-core/src/main/java/org/irods/jargon/core/packinstr/DataObjInp.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/packinstr/DataObjInp.java
@@ -9,8 +9,8 @@ import java.util.List;
 import org.irods.jargon.core.checksum.ChecksumValue;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.packinstr.TransferOptions.PutOptions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Translation of a DataObjInp operation into XML protocol format.
@@ -78,7 +78,7 @@ public class DataObjInp extends AbstractIRODSPackingInstruction {
 
 	private boolean initialPutGetCall = true;
 
-	private static Logger log = LoggerFactory.getLogger(DataObjInp.class);
+	private static Logger log = LogManager.getLogger(DataObjInp.class);
 
 	public static final int DEFAULT_CREATE_MODE = 33188;
 	public static final int EXEC_CREATE_MODE = 33261;

--- a/jargon-core/src/main/java/org/irods/jargon/core/packinstr/DataObjRead.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/packinstr/DataObjRead.java
@@ -5,8 +5,8 @@ package org.irods.jargon.core.packinstr;
 
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.utils.IRODSConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Translation of a DataObjRead operation into XML protocol format.
@@ -22,7 +22,7 @@ public class DataObjRead extends AbstractIRODSPackingInstruction {
 	public static final String LEN = "len";
 
 	public static final int READ_FILE_API_NBR = 603;
-	private Logger log = LoggerFactory.getLogger(this.getClass());
+	private Logger log = LogManager.getLogger(this.getClass());
 
 	private final int fileDescriptor;
 	private final long length;

--- a/jargon-core/src/main/java/org/irods/jargon/core/packinstr/ExecMyRuleInp.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/packinstr/ExecMyRuleInp.java
@@ -10,8 +10,8 @@ import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.rule.IRODSRule;
 import org.irods.jargon.core.rule.IRODSRuleParameter;
 import org.irods.jargon.core.utils.IRODSConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Immutable object gives translation of an ExecMyRuleInp operation into XML
@@ -54,7 +54,7 @@ public final class ExecMyRuleInp extends AbstractIRODSPackingInstruction {
 	private final String zone;
 	private boolean listAvailableRuleEnginesMode = false;
 
-	private static final Logger log = LoggerFactory.getLogger(ExecMyRuleInp.class);
+	private static final Logger log = LogManager.getLogger(ExecMyRuleInp.class);
 
 	/**
 	 * Create an instance of this packing instruction.

--- a/jargon-core/src/main/java/org/irods/jargon/core/packinstr/StructFileExtAndRegInp.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/packinstr/StructFileExtAndRegInp.java
@@ -5,8 +5,8 @@ import java.util.List;
 
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.utils.IRODSConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Translation of a StructFileExtAndRegInp operation into XML protocol format.
@@ -41,7 +41,7 @@ public final class StructFileExtAndRegInp extends AbstractIRODSPackingInstructio
 
 	private ForceOptions forceOption = ForceOptions.NO_FORCE;
 
-	private static final Logger LOG = LoggerFactory.getLogger(StructFileExtAndRegInp.class);
+	private static final Logger LOG = LogManager.getLogger(StructFileExtAndRegInp.class);
 
 	public enum ForceOptions {
 		FORCE, NO_FORCE

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/AbstractAuditAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/AbstractAuditAOImpl.java
@@ -23,8 +23,8 @@ import org.irods.jargon.core.query.QueryConditionOperators;
 import org.irods.jargon.core.query.RodsGenQueryEnum;
 import org.irods.jargon.core.utils.IRODSDataConversionUtil;
 import org.irods.jargon.core.utils.MiscIRODSUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * This abstract class handles common collection and data object functionality.
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractAuditAOImpl extends IRODSGenericAO {
 
 	protected final transient IRODSGenQueryExecutor irodsGenQueryExecutor;
-	public static final Logger log = LoggerFactory.getLogger(AbstractAuditAOImpl.class);
+	public static final Logger log = LogManager.getLogger(AbstractAuditAOImpl.class);
 
 	/**
 	 * Default constructor as invoked by {@link IRODSAccessObjectFactory}

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/ApiPluginExecutorImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/ApiPluginExecutorImpl.java
@@ -7,8 +7,8 @@ import org.irods.jargon.core.connection.IRODSAccount;
 import org.irods.jargon.core.connection.IRODSSession;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.packinstr.IRodsPI;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * @author conwaymc
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
  */
 class ApiPluginExecutorImpl extends IRODSGenericAO implements ApiPluginExecutor {
 
-	private static Logger log = LoggerFactory.getLogger(ApiPluginExecutorImpl.class);
+	private static Logger log = LogManager.getLogger(ApiPluginExecutorImpl.class);
 
 	/**
 	 * @param irodsSession

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/BulkFileOperationsAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/BulkFileOperationsAOImpl.java
@@ -5,8 +5,8 @@ import org.irods.jargon.core.connection.IRODSSession;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.packinstr.StructFileExtAndRegInp;
 import org.irods.jargon.core.packinstr.StructFileExtAndRegInp.BundleType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Object to handle bundled file operations. This object contains functionality
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
  */
 public class BulkFileOperationsAOImpl extends IRODSGenericAO implements BulkFileOperationsAO {
 
-	public static final Logger log = LoggerFactory.getLogger(BulkFileOperationsAOImpl.class);
+	public static final Logger log = LogManager.getLogger(BulkFileOperationsAOImpl.class);
 
 	/**
 	 * Get the extension typically associated with a bundle type

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/CollectionAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/CollectionAOImpl.java
@@ -54,8 +54,8 @@ import org.irods.jargon.core.utils.FederationEnabled;
 import org.irods.jargon.core.utils.IRODSDataConversionUtil;
 import org.irods.jargon.core.utils.MiscIRODSUtils;
 import org.irods.jargon.core.utils.RuleUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Access object handles various operations for an IRODS Collection.
@@ -76,7 +76,7 @@ public final class CollectionAOImpl extends FileCatalogObjectAOImpl implements C
 	private final IRODSFileFactory irodsFileFactory = new IRODSFileFactoryImpl(getIRODSSession(), getIRODSAccount());
 	private final IRODSGenQueryExecutor irodsGenQueryExecutor = new IRODSGenQueryExecutorImpl(getIRODSSession(),
 			getIRODSAccount());
-	public static final Logger log = LoggerFactory.getLogger(CollectionAOImpl.class);
+	public static final Logger log = LogManager.getLogger(CollectionAOImpl.class);
 
 	/**
 	 * Default constructor

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/CollectionAndDataObjectListAndSearchAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/CollectionAndDataObjectListAndSearchAOImpl.java
@@ -36,8 +36,8 @@ import org.irods.jargon.core.utils.FederationEnabled;
 import org.irods.jargon.core.utils.IRODSDataConversionUtil;
 import org.irods.jargon.core.utils.MiscIRODSUtils;
 import org.irods.jargon.core.utils.Overheaded;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * This access object contains methods that can assist in searching across
@@ -61,7 +61,7 @@ public class CollectionAndDataObjectListAndSearchAOImpl extends IRODSGenericAO
 		implements CollectionAndDataObjectListAndSearchAO {
 
 	private SpecificQueryAO specificQueryAO;
-	public static final Logger log = LoggerFactory.getLogger(CollectionAndDataObjectListAndSearchAOImpl.class);
+	public static final Logger log = LogManager.getLogger(CollectionAndDataObjectListAndSearchAOImpl.class);
 	private final CollectionListingUtils collectionListingUtils;
 
 	protected CollectionAndDataObjectListAndSearchAOImpl(final IRODSSession irodsSession,

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/CollectionAuditAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/CollectionAuditAOImpl.java
@@ -9,8 +9,8 @@ import org.irods.jargon.core.exception.FileNotFoundException;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.pub.domain.AuditedAction;
 import org.irods.jargon.core.pub.io.IRODSFile;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Represents audit trail capabilities for collections
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CollectionAuditAOImpl extends AbstractAuditAOImpl implements CollectionAuditAO {
 
-	public static final Logger log = LoggerFactory.getLogger(CollectionAuditAOImpl.class);
+	public static final Logger log = LogManager.getLogger(CollectionAuditAOImpl.class);
 	public static final char COMMA = ',';
 
 	/**

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/CollectionListingUtils.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/CollectionListingUtils.java
@@ -36,8 +36,8 @@ import org.irods.jargon.core.query.RodsGenQueryEnum;
 import org.irods.jargon.core.utils.CollectionAndPath;
 import org.irods.jargon.core.utils.IRODSDataConversionUtil;
 import org.irods.jargon.core.utils.MiscIRODSUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Generic utils (for the package) to do collection listings
@@ -51,7 +51,7 @@ class CollectionListingUtils {
 	private final IRODSAccessObjectFactory irodsAccessObjectFactory;
 	public static final String QUERY_EXCEPTION_FOR_QUERY = "query exception for  query:";
 
-	static final Logger log = LoggerFactory.getLogger(CollectionListingUtils.class);
+	static final Logger log = LogManager.getLogger(CollectionListingUtils.class);
 
 	/**
 	 * This is a compensating method used to deal with the top of the tree when

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/CollectionPagerAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/CollectionPagerAOImpl.java
@@ -14,8 +14,8 @@ import org.irods.jargon.core.query.PagingAwareCollectionListing;
 import org.irods.jargon.core.query.PagingAwareCollectionListing.PagingStyle;
 import org.irods.jargon.core.query.PagingAwareCollectionListingDescriptor;
 import org.irods.jargon.core.utils.MiscIRODSUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Improved facility to list under a parent collection in a manner that supports
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CollectionPagerAOImpl extends IRODSGenericAO implements CollectionPagerAO {
 
-	public static final Logger log = LoggerFactory.getLogger(CollectionPagerAOImpl.class);
+	public static final Logger log = LogManager.getLogger(CollectionPagerAOImpl.class);
 
 	private CollectionAndDataObjectListAndSearchAO collectionAndDataObjectListAndSearchAO;
 

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/DataAOHelper.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/DataAOHelper.java
@@ -45,8 +45,8 @@ import org.irods.jargon.core.transfer.TransferControlBlock;
 import org.irods.jargon.core.transfer.TransferStatus.TransferType;
 import org.irods.jargon.core.transfer.TransferStatusCallbackListener;
 import org.irods.jargon.core.utils.IRODSDataConversionUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * This helper class encapsulates lower-level helper code for the
@@ -58,7 +58,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 public final class DataAOHelper extends AOHelper {
-	public static final Logger log = LoggerFactory.getLogger(DataAOHelper.class);
+	public static final Logger log = LogManager.getLogger(DataAOHelper.class);
 
 	private final IRODSAccessObjectFactory irodsAccessObjectFactory;
 	private final IRODSAccount irodsAccount;

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/DataObjectAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/DataObjectAOImpl.java
@@ -89,8 +89,8 @@ import org.irods.jargon.core.utils.LocalFileUtils;
 import org.irods.jargon.core.utils.MiscIRODSUtils;
 import org.irods.jargon.core.utils.Overheaded;
 import org.irods.jargon.core.utils.RuleUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Access Object provides 'DAO' operations on IRODS Data Objects (files).
@@ -113,7 +113,7 @@ public final class DataObjectAOImpl extends FileCatalogObjectAOImpl implements D
 	private static final String ERROR_IN_PARALLEL_TRANSFER = "error in parallel transfer";
 	private static final String NULL_LOCAL_FILE = "null local file";
 	private static final String NULL_OR_EMPTY_ABSOLUTE_PATH = "null or empty absolutePath";
-	public static final Logger log = LoggerFactory.getLogger(DataObjectAOImpl.class);
+	public static final Logger log = LogManager.getLogger(DataObjectAOImpl.class);
 	private transient final DataAOHelper dataAOHelper = new DataAOHelper(getIRODSAccessObjectFactory(),
 			getIRODSAccount());
 	private transient final IRODSGenQueryExecutor irodsGenQueryExecutor;

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/DataObjectAuditAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/DataObjectAuditAOImpl.java
@@ -9,8 +9,8 @@ import org.irods.jargon.core.exception.FileNotFoundException;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.pub.domain.AuditedAction;
 import org.irods.jargon.core.pub.io.IRODSFile;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Represents audit trail capabilities for data objects.
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DataObjectAuditAOImpl extends AbstractAuditAOImpl implements DataObjectAuditAO {
 
-	public static final Logger log = LoggerFactory.getLogger(DataObjectAuditAOImpl.class);
+	public static final Logger log = LogManager.getLogger(DataObjectAuditAOImpl.class);
 	public static final char COMMA = ',';
 
 	/**

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/DataObjectChecksumUtilitiesAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/DataObjectChecksumUtilitiesAOImpl.java
@@ -18,8 +18,8 @@ import org.irods.jargon.core.packinstr.DataObjInp;
 import org.irods.jargon.core.packinstr.Tag;
 import org.irods.jargon.core.pub.domain.ObjStat;
 import org.irods.jargon.core.pub.io.IRODSFile;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Introduced as checksum operations became more complicated in
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DataObjectChecksumUtilitiesAOImpl extends IRODSGenericAO implements DataObjectChecksumUtilitiesAO {
 
-	public static final Logger log = LoggerFactory.getLogger(DataObjectChecksumUtilitiesAOImpl.class);
+	public static final Logger log = LogManager.getLogger(DataObjectChecksumUtilitiesAOImpl.class);
 	private final ChecksumManager checksumManager;
 	private final CollectionAndDataObjectListAndSearchAO collectionAndDataObjectListAndSearchAO;
 

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/DataTransferOperationsImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/DataTransferOperationsImpl.java
@@ -23,8 +23,8 @@ import org.irods.jargon.core.transfer.TransferStatus.TransferType;
 import org.irods.jargon.core.transfer.TransferStatusCallbackListener;
 import org.irods.jargon.core.utils.LocalFileUtils;
 import org.irods.jargon.core.utils.MiscIRODSUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * This object centralizes data transfer operations for iRODS, and provides
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class DataTransferOperationsImpl extends IRODSGenericAO implements DataTransferOperations {
 
-	private static Logger log = LoggerFactory.getLogger(DataTransferOperationsImpl.class);
+	private static Logger log = LogManager.getLogger(DataTransferOperationsImpl.class);
 	private TransferOperationsHelper transferOperationsHelper = null;
 
 	private DataObjectAO dataObjectAO = null;

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/EnvironmentalInfoAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/EnvironmentalInfoAOImpl.java
@@ -29,8 +29,8 @@ import org.irods.jargon.core.rule.IrodsRuleInvocationTypeEnum;
 import org.irods.jargon.core.rule.RuleInvocationConfiguration;
 import org.irods.jargon.core.transform.ClientHintsTransform;
 import org.irods.jargon.core.utils.IRODSConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Access object to access information about an IRODS Server
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 public class EnvironmentalInfoAOImpl extends IRODSGenericAO implements EnvironmentalInfoAO {
 
-	public static final Logger log = LoggerFactory.getLogger(EnvironmentalInfoAOImpl.class);
+	public static final Logger log = LogManager.getLogger(EnvironmentalInfoAOImpl.class);
 
 	private final EnvironmentalInfoAccessor environmentalInfoAccessor;
 

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/FileCatalogObjectAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/FileCatalogObjectAOImpl.java
@@ -18,8 +18,8 @@ import org.irods.jargon.core.pub.io.IRODSFile;
 import org.irods.jargon.core.query.CollectionAndDataObjectListingEntry;
 import org.irods.jargon.core.utils.CollectionAndPath;
 import org.irods.jargon.core.utils.MiscIRODSUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Access object representing the file catalog in iRODS. This object is the
@@ -33,7 +33,7 @@ public abstract class FileCatalogObjectAOImpl extends IRODSGenericAO implements 
 
 	protected transient final CollectionAndDataObjectListAndSearchAO collectionAndDataObjectListAndSearchAO;
 
-	public static final Logger log = LoggerFactory.getLogger(FileCatalogObjectAOImpl.class);
+	public static final Logger log = LogManager.getLogger(FileCatalogObjectAOImpl.class);
 	public static final String STR_PI = "STR_PI";
 	public static final String MY_STR = "myStr";
 	/**

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/IRODSAccessObjectFactoryImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/IRODSAccessObjectFactoryImpl.java
@@ -12,8 +12,8 @@ import org.irods.jargon.core.packinstr.TransferOptions;
 import org.irods.jargon.core.pub.io.IRODSFileFactory;
 import org.irods.jargon.core.pub.io.IRODSFileFactoryImpl;
 import org.irods.jargon.core.transfer.TransferControlBlock;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Factory to produce IRODS access objects. This is the key object which can be
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class IRODSAccessObjectFactoryImpl implements IRODSAccessObjectFactory {
 
-	private static final Logger log = LoggerFactory.getLogger(IRODSAccessObjectFactoryImpl.class);
+	private static final Logger log = LogManager.getLogger(IRODSAccessObjectFactoryImpl.class);
 
 	private IRODSSession irodsSession;
 

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/IRODSFileSystem.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/IRODSFileSystem.java
@@ -14,8 +14,8 @@ import org.irods.jargon.core.connection.JargonProperties;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.pub.io.IRODSFileFactory;
 import org.irods.jargon.core.pub.io.IRODSFileFactoryImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * This class is a simplified way of obtaining a connection and getting
@@ -68,7 +68,7 @@ public final class IRODSFileSystem {
 	private final IRODSSession irodsSession;
 	private transient IRODSAccessObjectFactory irodsAccessObjectFactory = null;
 
-	private static final Logger log = LoggerFactory.getLogger(IRODSFileSystem.class);
+	private static final Logger log = LogManager.getLogger(IRODSFileSystem.class);
 
 	/**
 	 * Create an instance based on a particular type of protocol manager (e.g. a

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/IRODSFileSystemAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/IRODSFileSystemAOImpl.java
@@ -47,8 +47,8 @@ import org.irods.jargon.core.query.QueryConditionOperators;
 import org.irods.jargon.core.query.RodsGenQueryEnum;
 import org.irods.jargon.core.utils.IRODSConstants;
 import org.irods.jargon.core.utils.MiscIRODSUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -64,7 +64,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
  */
 public final class IRODSFileSystemAOImpl extends IRODSGenericAO implements IRODSFileSystemAO {
 
-	static Logger log = LoggerFactory.getLogger(IRODSFileSystemAOImpl.class);
+	static Logger log = LogManager.getLogger(IRODSFileSystemAOImpl.class);
 
 	private final IRODSGenQueryExecutor irodsGenQueryExecutor;
 	private final CollectionAndDataObjectListAndSearchAO collectionAndDataObjectListAndSearchAO;

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/IRODSGenQueryExecutorImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/IRODSGenQueryExecutorImpl.java
@@ -8,8 +8,8 @@ import org.irods.jargon.core.query.GenQueryProcessor;
 import org.irods.jargon.core.query.IRODSQueryResultSet;
 import org.irods.jargon.core.query.JargonQueryException;
 import org.irods.jargon.core.query.TranslatedIRODSGenQuery;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Implementation class that can process iquest-like queries using the genquery
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class IRODSGenQueryExecutorImpl extends IRODSGenericAO implements IRODSGenQueryExecutor {
 
-	private static final Logger log = LoggerFactory.getLogger(IRODSGenQueryExecutorImpl.class);
+	private static final Logger log = LogManager.getLogger(IRODSGenQueryExecutorImpl.class);
 
 	/**
 	 * enum describes how to handle closing of a query

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/IRODSGenericAO.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/IRODSGenericAO.java
@@ -14,8 +14,8 @@ import org.irods.jargon.core.packinstr.Tag;
 import org.irods.jargon.core.packinstr.TransferOptions;
 import org.irods.jargon.core.pub.io.IRODSFileFactory;
 import org.irods.jargon.core.transfer.TransferControlBlock;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * General base class for objects that interact with IRODS through a connection.
@@ -30,7 +30,7 @@ public abstract class IRODSGenericAO implements IRODSAccessObject {
 	private final boolean instrumented;
 	private IRODSAccessObjectFactory irodsAccessObjectFactory;
 
-	private static final Logger log = LoggerFactory.getLogger(IRODSGenericAO.class);
+	private static final Logger log = LogManager.getLogger(IRODSGenericAO.class);
 
 	/**
 	 * Constructor that initializes the access object with a pointer to the

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/IRODSRegistrationOfFilesAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/IRODSRegistrationOfFilesAOImpl.java
@@ -16,8 +16,8 @@ import org.irods.jargon.core.packinstr.Tag;
 import org.irods.jargon.core.protovalues.ChecksumEncodingEnum;
 import org.irods.jargon.core.utils.IRODSConstants;
 import org.irods.jargon.core.utils.LocalFileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Access Object that manages the registration of files, as managed by the iRODS
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  */
 public class IRODSRegistrationOfFilesAOImpl extends IRODSGenericAO implements IRODSRegistrationOfFilesAO {
 
-	static Logger log = LoggerFactory.getLogger(IRODSRegistrationOfFilesAOImpl.class);
+	static Logger log = LogManager.getLogger(IRODSRegistrationOfFilesAOImpl.class);
 
 	/**
 	 * @param irodsSession

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/MountedCollectionAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/MountedCollectionAOImpl.java
@@ -17,8 +17,8 @@ import org.irods.jargon.core.pub.io.IRODSFile;
 import org.irods.jargon.core.query.CollectionAndDataObjectListingEntry.ObjectType;
 import org.irods.jargon.core.transfer.TransferControlBlock;
 import org.irods.jargon.core.utils.Overheaded;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Manages soft links and mounted collections in iRODS. This access object can
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MountedCollectionAOImpl extends IRODSGenericAO implements MountedCollectionAO {
 
-	public static final Logger log = LoggerFactory.getLogger(MountedCollectionAOImpl.class);
+	public static final Logger log = LogManager.getLogger(MountedCollectionAOImpl.class);
 
 	/**
 	 * Default constructor to be called by the {@link IRODSAccessObjectFactory}

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/ProtocolExtensionPointImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/ProtocolExtensionPointImpl.java
@@ -6,8 +6,8 @@ import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.packinstr.IRodsPI;
 import org.irods.jargon.core.packinstr.Tag;
 import org.irods.jargon.core.utils.IRODSConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * This access object exposes a direct connection to iRODS such that protocol
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ProtocolExtensionPointImpl extends IRODSGenericAO implements ProtocolExtensionPoint {
 
-	private static Logger log = LoggerFactory.getLogger(ProtocolExtensionPointImpl.class);
+	private static Logger log = LogManager.getLogger(ProtocolExtensionPointImpl.class);
 
 	protected ProtocolExtensionPointImpl(final IRODSSession irodsSession, final IRODSAccount irodsAccount)
 			throws JargonException {

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/QuotaAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/QuotaAOImpl.java
@@ -14,8 +14,8 @@ import org.irods.jargon.core.query.IRODSQueryResultRow;
 import org.irods.jargon.core.query.IRODSQueryResultSetInterface;
 import org.irods.jargon.core.query.SimpleQuery;
 import org.irods.jargon.core.utils.IRODSDataConversionUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Access object to manage quota information for users and groups.
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  */
 public class QuotaAOImpl extends IRODSGenericAO implements QuotaAO {
 
-	public static final Logger log = LoggerFactory.getLogger(QuotaAOImpl.class);
+	public static final Logger log = LogManager.getLogger(QuotaAOImpl.class);
 	private SimpleQueryExecutorAO simpleQueryExcecutor = null;
 
 	public static final String ALL_QUOTA_GLOBAL_QUERY = "select user_name, R_USER_MAIN.zone_name, quota_limit, quota_over, R_QUOTA_MAIN.modify_ts from R_QUOTA_MAIN, R_USER_MAIN where R_USER_MAIN.user_id = R_QUOTA_MAIN.user_id and R_QUOTA_MAIN.resc_id = 0";

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/RemoteExecutionOfCommandsAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/RemoteExecutionOfCommandsAOImpl.java
@@ -10,8 +10,8 @@ import org.irods.jargon.core.connection.IRODSSession;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.remoteexecute.RemoteExecuteServiceImpl;
 import org.irods.jargon.core.remoteexecute.RemoteExecutionService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Access object implementation to remotely execute scripts and commands on
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RemoteExecutionOfCommandsAOImpl extends IRODSGenericAO implements RemoteExecutionOfCommandsAO {
 
-	private static final Logger log = LoggerFactory.getLogger(RemoteExecutionOfCommandsAOImpl.class);
+	private static final Logger log = LogManager.getLogger(RemoteExecutionOfCommandsAOImpl.class);
 
 	/**
 	 * @param irodsSession

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/ResourceAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/ResourceAOImpl.java
@@ -34,8 +34,8 @@ import org.irods.jargon.core.query.QueryConditionOperators;
 import org.irods.jargon.core.query.RodsGenQueryEnum;
 import org.irods.jargon.core.utils.AccessObjectQueryProcessingUtils;
 import org.irods.jargon.core.utils.IRODSDataConversionUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Access to CRUD and query operations on IRODS Resource.
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class ResourceAOImpl extends IRODSGenericAO implements ResourceAO {
 
-	private final Logger log = LoggerFactory.getLogger(this.getClass());
+	private final Logger log = LogManager.getLogger(this.getClass());
 	private final ZoneAO zoneAO;
 
 	/**

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/ResourceGroupAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/ResourceGroupAOImpl.java
@@ -16,8 +16,8 @@ import org.irods.jargon.core.query.IRODSGenQueryBuilder;
 import org.irods.jargon.core.query.IRODSQueryResultRow;
 import org.irods.jargon.core.query.JargonQueryException;
 import org.irods.jargon.core.query.RodsGenQueryEnum;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Access object that represents resource groups and related operations in
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ResourceGroupAOImpl extends IRODSGenericAO implements ResourceGroupAO {
 
-	private static Logger log = LoggerFactory.getLogger(ResourceGroupAOImpl.class);
+	private static Logger log = LogManager.getLogger(ResourceGroupAOImpl.class);
 
 	/**
 	 * @param irodsSession

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/RuleProcessingAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/RuleProcessingAOImpl.java
@@ -51,8 +51,8 @@ import org.irods.jargon.core.utils.Base64;
 import org.irods.jargon.core.utils.IRODSConstants;
 import org.irods.jargon.core.utils.LocalFileUtils;
 import org.irods.jargon.core.utils.TagHandlingUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -79,7 +79,7 @@ public final class RuleProcessingAOImpl extends IRODSGenericAO implements RulePr
 	public static final String SVALUE = "svalue";
 	public static final String COMMA = ",";
 
-	private static final Logger log = LoggerFactory.getLogger(RuleProcessingAOImpl.class);
+	private static final Logger log = LogManager.getLogger(RuleProcessingAOImpl.class);
 
 	public static final String CL_PUT_ACTION = "CL_PUT_ACTION";
 	public static final String CL_GET_ACTION = "CL_GET_ACTION";

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/SimpleQueryExecutorAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/SimpleQueryExecutorAOImpl.java
@@ -18,8 +18,8 @@ import org.irods.jargon.core.query.IRODSQueryResultRow;
 import org.irods.jargon.core.query.IRODSQueryResultSetInterface;
 import org.irods.jargon.core.query.IRODSSimpleQueryResultSet;
 import org.irods.jargon.core.query.SimpleQuery;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Access object to execute queries using the iRODS Simple Query facility. This
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SimpleQueryExecutorAOImpl extends IRODSGenericAO implements SimpleQueryExecutorAO {
 
-	private static final Logger log = LoggerFactory.getLogger(SimpleQueryExecutorAOImpl.class);
+	private static final Logger log = LogManager.getLogger(SimpleQueryExecutorAOImpl.class);
 
 	public static final String OUT_BUF = "outBuf";
 

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/SpecificQueryAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/SpecificQueryAOImpl.java
@@ -21,13 +21,13 @@ import org.irods.jargon.core.query.SpecificQuery;
 import org.irods.jargon.core.query.SpecificQueryResultSet;
 import org.irods.jargon.core.utils.MiscIRODSUtils;
 import org.irods.jargon.core.utils.Overheaded;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class SpecificQueryAOImpl extends IRODSGenericAO implements SpecificQueryAO {
 
 	private static final String EXECUTING_SQUERY_PI = "executing specific query PI";
-	public static final Logger log = LoggerFactory.getLogger(SpecificQueryAOImpl.class);
+	public static final Logger log = LogManager.getLogger(SpecificQueryAOImpl.class);
 
 	protected SpecificQueryAOImpl(final IRODSSession irodsSession, final IRODSAccount irodsAccount)
 			throws SpecificQueryException, JargonException {

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/Stream2StreamAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/Stream2StreamAOImpl.java
@@ -23,8 +23,8 @@ import org.irods.jargon.core.packinstr.DataObjInp.OpenFlags;
 import org.irods.jargon.core.pub.io.IRODSFile;
 import org.irods.jargon.core.pub.io.IRODSFileOutputStream;
 import org.irods.jargon.core.utils.ChannelTools;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Helpful object for stream to stream copies, also handles byte arrays (as
@@ -41,7 +41,7 @@ public class Stream2StreamAOImpl extends IRODSGenericAO implements Stream2Stream
 	// private final int bufferSize = this.getJargonProperties().get
 	private static final int bufferSize = 32 * 1024; // FIXME: temp code
 
-	public static final Logger log = LoggerFactory.getLogger(Stream2StreamAOImpl.class);
+	public static final Logger log = LogManager.getLogger(Stream2StreamAOImpl.class);
 
 	public Stream2StreamAOImpl(final IRODSSession irodsSession, final IRODSAccount irodsAccount)
 			throws JargonException {

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/TransferOperationsHelper.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/TransferOperationsHelper.java
@@ -15,8 +15,8 @@ import org.irods.jargon.core.transfer.TransferStatus.TransferState;
 import org.irods.jargon.core.transfer.TransferStatus.TransferType;
 import org.irods.jargon.core.transfer.TransferStatusCallbackListener;
 import org.irods.jargon.core.transfer.TransferStatusCallbackListener.FileStatusCallbackResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * @author Mike Conway - DICE (www.irods.org)
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  */
 final class TransferOperationsHelper {
 
-	static Logger log = LoggerFactory.getLogger(TransferOperationsHelper.class);
+	static Logger log = LogManager.getLogger(TransferOperationsHelper.class);
 	private final DataObjectAOImpl dataObjectAO;
 	private final CollectionAO collectionAO;
 

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/TrashOperationsAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/TrashOperationsAOImpl.java
@@ -17,8 +17,8 @@ import org.irods.jargon.core.pub.domain.ObjStat;
 import org.irods.jargon.core.pub.io.IRODSFile;
 import org.irods.jargon.core.utils.IRODSConstants;
 import org.irods.jargon.core.utils.MiscIRODSUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Implementation of trash operations
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TrashOperationsAOImpl extends IRODSGenericAO implements TrashOperationsAO {
 
-	public static final Logger log = LoggerFactory.getLogger(TrashOperationsAOImpl.class);
+	public static final Logger log = LogManager.getLogger(TrashOperationsAOImpl.class);
 
 	/**
 	 * @param irodsSession {@link IRODSSession}

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/UserAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/UserAOImpl.java
@@ -37,8 +37,8 @@ import org.irods.jargon.core.query.QueryConditionOperators;
 import org.irods.jargon.core.query.RodsGenQueryEnum;
 import org.irods.jargon.core.security.IRODSPasswordUtilities;
 import org.irods.jargon.core.utils.FederationEnabled;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Class to access underlying user information in IRODS.
@@ -57,7 +57,7 @@ public final class UserAOImpl extends IRODSGenericAO implements UserAO {
 
 	private static final int DEFAULT_REC_COUNT = 500;
 
-	Logger log = LoggerFactory.getLogger(this.getClass());
+	Logger log = LogManager.getLogger(this.getClass());
 	private static final char COMMA = ',';
 	private static final String AND = " AND ";
 	private static final String EQUALS = " = ";

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/UserGroupAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/UserGroupAOImpl.java
@@ -29,8 +29,8 @@ import org.irods.jargon.core.query.QueryConditionOperators;
 import org.irods.jargon.core.query.RodsGenQueryEnum;
 import org.irods.jargon.core.utils.IRODSDataConversionUtil;
 import org.irods.jargon.core.utils.MiscIRODSUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Operations for IRODS user groups.
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class UserGroupAOImpl extends IRODSGenericAO implements UserGroupAO {
 
-	private final Logger log = LoggerFactory.getLogger(this.getClass());
+	private final Logger log = LogManager.getLogger(this.getClass());
 	private static final char COMMA = ',';
 	private static final String RODS_GROUP = "rodsgroup";
 	private IRODSGenQueryExecutor irodsGenQueryExecutor = null;

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/ZoneAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/ZoneAOImpl.java
@@ -22,8 +22,8 @@ import org.irods.jargon.core.query.IRODSQueryResultSetInterface;
 import org.irods.jargon.core.query.JargonQueryException;
 import org.irods.jargon.core.query.RodsGenQueryEnum;
 import org.irods.jargon.core.utils.IRODSDataConversionUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Access to CRUD and query operations on IRODS Zone.
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class ZoneAOImpl extends IRODSGenericAO implements ZoneAO {
 
-	private static final Logger log = LoggerFactory.getLogger(ZoneAOImpl.class);
+	private static final Logger log = LogManager.getLogger(ZoneAOImpl.class);
 
 	protected ZoneAOImpl(final IRODSSession irodsSession, final IRODSAccount irodsAccount) throws JargonException {
 		super(irodsSession, irodsAccount);

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/aohelper/CollectionAOHelper.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/aohelper/CollectionAOHelper.java
@@ -23,8 +23,8 @@ import org.irods.jargon.core.query.JargonQueryException;
 import org.irods.jargon.core.query.QueryConditionOperators;
 import org.irods.jargon.core.query.RodsGenQueryEnum;
 import org.irods.jargon.core.utils.IRODSDataConversionUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Helper clas to support the {@link org.irods.jargon.core.pub.CollectionAO}.
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CollectionAOHelper extends AOHelper {
 
-	public static final Logger log = LoggerFactory.getLogger(CollectionAOHelper.class);
+	public static final Logger log = LogManager.getLogger(CollectionAOHelper.class);
 
 	/**
 	 * Create a set of selects for a collection, used in general query

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/aohelper/UserAOHelper.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/aohelper/UserAOHelper.java
@@ -16,8 +16,8 @@ import org.irods.jargon.core.query.JargonQueryException;
 import org.irods.jargon.core.query.QueryConditionOperators;
 import org.irods.jargon.core.query.RodsGenQueryEnum;
 import org.irods.jargon.core.utils.IRODSDataConversionUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * General helper methods for users and user groups.
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 public class UserAOHelper {
 
 	private static final char COMMA = ',';
-	static Logger log = LoggerFactory.getLogger(UserAOHelper.class);
+	static Logger log = LogManager.getLogger(UserAOHelper.class);
 
 	/**
 	 * Handy method will build the select portion of a gen query that accesses user

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/io/FileIOOperationsAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/io/FileIOOperationsAOImpl.java
@@ -15,8 +15,8 @@ import org.irods.jargon.core.packinstr.Tag;
 import org.irods.jargon.core.pub.DataObjectChecksumUtilitiesAO;
 import org.irods.jargon.core.pub.IRODSGenericAO;
 import org.irods.jargon.core.utils.IRODSConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * @author Mike Conway - DICE (www.irods.org)
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 
 public final class FileIOOperationsAOImpl extends IRODSGenericAO implements FileIOOperations {
 
-	static Logger log = LoggerFactory.getLogger(FileIOOperationsAOImpl.class);
+	static Logger log = LogManager.getLogger(FileIOOperationsAOImpl.class);
 
 	public FileIOOperationsAOImpl(final IRODSSession irodsSession, final IRODSAccount irodsAccount)
 			throws JargonException {

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/io/IRODSFileFactoryImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/io/IRODSFileFactoryImpl.java
@@ -20,8 +20,8 @@ import org.irods.jargon.core.pub.IRODSFileSystemAOImpl;
 import org.irods.jargon.core.pub.IRODSGenericAO;
 import org.irods.jargon.core.utils.IRODSUriUtils;
 import org.irods.jargon.core.utils.MiscIRODSUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 //import org.perf4j.StopWatch;
 //import org.perf4j.slf4j.Slf4JStopWatch;
 
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 public final class IRODSFileFactoryImpl extends IRODSGenericAO implements IRODSFileFactory {
 
 	public static final String PATH_SEPARATOR = "/";
-	static Logger log = LoggerFactory.getLogger(IRODSFileFactoryImpl.class);
+	static Logger log = LogManager.getLogger(IRODSFileFactoryImpl.class);
 
 	public IRODSFileFactoryImpl(final IRODSSession irodsSession, final IRODSAccount irodsAccount)
 			throws JargonException {

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/io/IRODSFileImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/io/IRODSFileImpl.java
@@ -35,8 +35,8 @@ import org.irods.jargon.core.pub.domain.ObjStat;
 import org.irods.jargon.core.pub.domain.pluggable.ReplicaClose;
 import org.irods.jargon.core.query.CollectionAndDataObjectListingEntry.ObjectType;
 import org.irods.jargon.core.utils.MiscIRODSUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -57,7 +57,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
  */
 
 public class IRODSFileImpl extends File implements IRODSFile {
-	static Logger log = LoggerFactory.getLogger(IRODSFileImpl.class);
+	static Logger log = LogManager.getLogger(IRODSFileImpl.class);
 
 	private IRODSFileSystemAO irodsFileSystemAO = null;
 

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/io/IRODSFileInputStream.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/io/IRODSFileInputStream.java
@@ -7,8 +7,8 @@ import java.io.InputStream;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.exception.JargonRuntimeException;
 import org.irods.jargon.core.packinstr.DataObjInp.OpenFlags;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * IRODS specific implementation of the {@code java.io.FileInputStream}. This
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  */
 public class IRODSFileInputStream extends InputStream {
 
-	private final Logger log = LoggerFactory.getLogger(this.getClass());
+	private final Logger log = LogManager.getLogger(this.getClass());
 
 	private transient final IRODSFile irodsFile;
 	private transient final FileIOOperations fileIOOperations;

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/io/IRODSFileOutputStream.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/io/IRODSFileOutputStream.java
@@ -9,8 +9,8 @@ import org.irods.jargon.core.exception.JargonRuntimeException;
 import org.irods.jargon.core.exception.NoResourceDefinedException;
 import org.irods.jargon.core.packinstr.DataObjInp.OpenFlags;
 import org.irods.jargon.core.pub.io.FileIOOperations.SeekWhenceType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * IRODS-specific implementation of {@code java.io.FileOutputStream}
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  */
 public class IRODSFileOutputStream extends OutputStream {
 
-	private final Logger log = LoggerFactory.getLogger(this.getClass());
+	private final Logger log = LogManager.getLogger(this.getClass());
 
 	private final IRODSFile irodsFile;
 	private final FileIOOperations fileIOOperations;

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/io/IRODSFileReader.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/io/IRODSFileReader.java
@@ -10,8 +10,8 @@ import java.io.Reader;
 
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.exception.JargonRuntimeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * iRODS-specific implementation of the {@code java.io.Reader}.
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 public class IRODSFileReader extends Reader {
 
 	private final transient IRODSFileInputStream irodsFileInputStream;
-	public static Logger log = LoggerFactory.getLogger(IRODSFileReader.class);
+	public static Logger log = LogManager.getLogger(IRODSFileReader.class);
 	private final String connectionEncoding;
 
 	/**

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/io/IRODSFileSystemAOHelper.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/io/IRODSFileSystemAOHelper.java
@@ -10,8 +10,8 @@ import org.irods.jargon.core.query.GenQueryBuilderException;
 import org.irods.jargon.core.query.IRODSGenQueryBuilder;
 import org.irods.jargon.core.query.QueryConditionOperators;
 import org.irods.jargon.core.query.RodsGenQueryEnum;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Helper functions for the {@code IRODSFileSystemAO}, essentially to make that
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  */
 public class IRODSFileSystemAOHelper extends AOHelper {
 
-	static Logger log = LoggerFactory.getLogger(IRODSFileSystemAOHelper.class);
+	static Logger log = LogManager.getLogger(IRODSFileSystemAOHelper.class);
 
 	/**
 	 * List all directories under the path.

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/io/IRODSFileWriter.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/io/IRODSFileWriter.java
@@ -10,8 +10,8 @@ import java.io.Writer;
 
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.exception.JargonRuntimeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * iRODS specific implementation of a {@code java.io.Writer}
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 public class IRODSFileWriter extends Writer {
 
 	private final IRODSFileOutputStream irodsFileOutputStream;
-	public static Logger log = LoggerFactory.getLogger(IRODSFileWriter.class);
+	public static Logger log = LogManager.getLogger(IRODSFileWriter.class);
 	private final String connectionEncoding;
 
 	/**

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/io/IRODSRandomAccessFile.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/io/IRODSRandomAccessFile.java
@@ -13,8 +13,8 @@ import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.pub.io.FileIOOperations.SeekWhenceType;
 import org.irods.jargon.core.utils.BinaryDataFormat;
 import org.irods.jargon.core.utils.Host;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Instances of this class support I/O on random-access binary files. Methods on
@@ -58,7 +58,7 @@ import org.slf4j.LoggerFactory;
  */
 public class IRODSRandomAccessFile implements DataInput, DataOutput {
 
-	private static Logger log = LoggerFactory.getLogger(IRODSFileImpl.class);
+	private static Logger log = LogManager.getLogger(IRODSFileImpl.class);
 	private final FileIOOperations fileIOOperations;
 	private final IRODSFile irodsFile;
 	private long filePointer = 0;

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/io/PackingIrodsInputStream.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/io/PackingIrodsInputStream.java
@@ -8,8 +8,8 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.irods.jargon.core.exception.JargonRuntimeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Wrap an iRODS input stream in an accumulating buffer that will emulate reads
@@ -23,7 +23,7 @@ public class PackingIrodsInputStream extends InputStream {
 	private final IRODSFileInputStream irodsFileInputStream;
 	private ByteArrayInputStream byteArrayInputStream = null;
 	private final int bufferSizeForIrods;
-	private final Logger log = LoggerFactory.getLogger(this.getClass());
+	private final Logger log = LogManager.getLogger(this.getClass());
 	private boolean done = false;
 
 	public PackingIrodsInputStream(final IRODSFileInputStream irodsFileInputStream) {

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/io/PackingIrodsOutputStream.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/io/PackingIrodsOutputStream.java
@@ -7,8 +7,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * A stream that presents the normal api, but accumulates bytes written until at
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  */
 public class PackingIrodsOutputStream extends OutputStream {
 
-	private final Logger log = LoggerFactory.getLogger(this.getClass());
+	private final Logger log = LogManager.getLogger(this.getClass());
 
 	private int byteBufferSizeMax;
 	private ByteArrayOutputStream byteArrayOutputStream = null;

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/io/RemoteExecutionBinaryResultInputStream.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/io/RemoteExecutionBinaryResultInputStream.java
@@ -11,8 +11,8 @@ import org.irods.jargon.core.packinstr.ExecCmdStreamClose419;
 import org.irods.jargon.core.packinstr.FileReadInp;
 import org.irods.jargon.core.packinstr.Tag;
 import org.irods.jargon.core.utils.IRODSConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Special subclass of {@code InputStream} meant to encapsulate binary data
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RemoteExecutionBinaryResultInputStream extends InputStream {
 
-	public static final Logger log = LoggerFactory.getLogger(RemoteExecutionBinaryResultInputStream.class);
+	public static final Logger log = LogManager.getLogger(RemoteExecutionBinaryResultInputStream.class);
 
 	private final IRODSMidLevelProtocol irodsCommands;
 	private final int fileDescriptor;

--- a/jargon-core/src/main/java/org/irods/jargon/core/query/ExtensibleMetaDataMapping.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/query/ExtensibleMetaDataMapping.java
@@ -5,8 +5,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.irods.jargon.core.exception.JargonException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Contains an index of extensible meta-data attributes for this query. This
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class ExtensibleMetaDataMapping {
 
-	private static Logger log = LoggerFactory.getLogger(ExtensibleMetaDataMapping.class);
+	private static Logger log = LogManager.getLogger(ExtensibleMetaDataMapping.class);
 
 	// Map will be wrapped immutable at construction time
 	private Map<String, String> extensibleMappings = new HashMap<String, String>();

--- a/jargon-core/src/main/java/org/irods/jargon/core/query/ExtensibleMetadataPropertiesSource.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/query/ExtensibleMetadataPropertiesSource.java
@@ -10,8 +10,8 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.irods.jargon.core.exception.JargonException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * @author Mike Conway - DICE (www.irods.org) Creates an
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ExtensibleMetadataPropertiesSource implements ExtensibleMetaDataSource {
 
-	private static Logger log = LoggerFactory.getLogger(ExtensibleMetadataPropertiesSource.class);
+	private static Logger log = LogManager.getLogger(ExtensibleMetadataPropertiesSource.class);
 
 	private Map<String, String> extensibleMetaDataProperties = null;
 	private String propertiesFileName = "";

--- a/jargon-core/src/main/java/org/irods/jargon/core/query/GenQueryProcessor.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/query/GenQueryProcessor.java
@@ -13,8 +13,8 @@ import org.irods.jargon.core.packinstr.GenQueryInp;
 import org.irods.jargon.core.packinstr.Tag;
 import org.irods.jargon.core.pub.IRODSGenQueryExecutorImpl.QueryCloseBehavior;
 import org.irods.jargon.core.utils.IRODSConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Handles lower-level processing of GenQuery
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  */
 public class GenQueryProcessor {
 	private final IRODSMidLevelProtocol irodsCommands;
-	private static final Logger log = LoggerFactory.getLogger(GenQueryProcessor.class);
+	private static final Logger log = LogManager.getLogger(GenQueryProcessor.class);
 
 	/**
 	 * @param irodsCommands {@link IRODSMidLevelProtocol}

--- a/jargon-core/src/main/java/org/irods/jargon/core/query/IRODSGenQueryTranslator.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/query/IRODSGenQueryTranslator.java
@@ -7,8 +7,8 @@ import java.util.StringTokenizer;
 import org.irods.jargon.core.connection.IRODSServerProperties;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.query.GenQueryField.SelectFieldTypes;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Translate an IRODSQuery posed as a {@code String} query statement (as in
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 public class IRODSGenQueryTranslator {
 
 	private IRODSServerProperties irodsServerProperties;
-	private static Logger log = LoggerFactory.getLogger(IRODSGenQueryTranslator.class);
+	private static Logger log = LogManager.getLogger(IRODSGenQueryTranslator.class);
 	private ExtensibleMetaDataMapping extensibleMetaDataMapping = null;
 
 	public static final String[] operatorStrings = { "<>", "<=", ">=", "not in", "not between", "not like",

--- a/jargon-core/src/main/java/org/irods/jargon/core/query/QueryResultProcessingUtils.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/query/QueryResultProcessingUtils.java
@@ -9,8 +9,8 @@ import java.util.List;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.packinstr.GenQueryOut;
 import org.irods.jargon.core.packinstr.Tag;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Convenience methods for handling packing instructions that result from the
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
  */
 public class QueryResultProcessingUtils {
 
-	private static final Logger log = LoggerFactory.getLogger(QueryResultProcessingUtils.class);
+	private static final Logger log = LogManager.getLogger(QueryResultProcessingUtils.class);
 
 	/**
 	 * Given the raw response from iRODS, translate into a list of result rows for

--- a/jargon-core/src/main/java/org/irods/jargon/core/remoteexecute/RemoteExecuteServiceImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/remoteexecute/RemoteExecuteServiceImpl.java
@@ -14,8 +14,8 @@ import org.irods.jargon.core.packinstr.Tag;
 import org.irods.jargon.core.pub.io.RemoteExecutionBinaryResultInputStream;
 import org.irods.jargon.core.utils.Base64;
 import org.irods.jargon.core.utils.IRODSConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Service for running remote commands (scripts) on iRODS. This is equivalent to
@@ -39,7 +39,7 @@ public class RemoteExecuteServiceImpl implements RemoteExecutionService {
 	public static final String STREAMING_API_CUTOFF = "rods4.1";
 	private PathHandlingMode pathHandlingMode = PathHandlingMode.NONE;
 
-	private static final Logger log = LoggerFactory.getLogger(RemoteExecuteServiceImpl.class);
+	private static final Logger log = LogManager.getLogger(RemoteExecuteServiceImpl.class);
 	private static final String STATUS = "status";
 
 	@Override

--- a/jargon-core/src/main/java/org/irods/jargon/core/rule/AbstractRuleTranslator.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/rule/AbstractRuleTranslator.java
@@ -7,15 +7,15 @@ import java.util.StringTokenizer;
 import org.irods.jargon.core.connection.IRODSServerProperties;
 import org.irods.jargon.core.connection.JargonProperties;
 import org.irods.jargon.core.exception.JargonException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public abstract class AbstractRuleTranslator {
 
 	private static final String SPLAT = "*";
 	private final IRODSServerProperties irodsServerProperties;
 	private final RuleInvocationConfiguration ruleInvocationConfiguration;
-	Logger log = LoggerFactory.getLogger(this.getClass());
+	Logger log = LogManager.getLogger(this.getClass());
 	private final JargonProperties jargonProperties;
 
 	/**

--- a/jargon-core/src/main/java/org/irods/jargon/core/rule/IrodsRuleEngineRuleTranslator.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/rule/IrodsRuleEngineRuleTranslator.java
@@ -9,8 +9,8 @@ import org.irods.jargon.core.connection.JargonProperties;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.exception.OperationNotSupportedByThisServerException;
 import org.irods.jargon.core.pub.RuleProcessingAO.RuleProcessingType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Translates an iRODS user defined rule in plain text form into an
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
  */
 public class IrodsRuleEngineRuleTranslator extends AbstractRuleTranslator {
 
-	Logger log = LoggerFactory.getLogger(this.getClass());
+	Logger log = LogManager.getLogger(this.getClass());
 
 	/**
 	 * Default constructor with required dependencies

--- a/jargon-core/src/main/java/org/irods/jargon/core/rule/IrodsRuleFactory.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/rule/IrodsRuleFactory.java
@@ -8,8 +8,8 @@ import java.util.List;
 import org.irods.jargon.core.connection.IRODSAccount;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.pub.IRODSAccessObjectFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Factory to create iRODS rule representation {@link IRODSRule} from a raw
@@ -23,7 +23,7 @@ public class IrodsRuleFactory {
 	private final IRODSAccessObjectFactory irodsAccessObjectFactory;
 	private final IRODSAccount irodsAccount;
 
-	Logger log = LoggerFactory.getLogger(this.getClass());
+	Logger log = LogManager.getLogger(this.getClass());
 
 	/**
 	 * Constructor with required fields

--- a/jargon-core/src/main/java/org/irods/jargon/core/rule/OtherRuleTranslator.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/rule/OtherRuleTranslator.java
@@ -11,8 +11,8 @@ import org.irods.jargon.core.connection.IRODSServerProperties;
 import org.irods.jargon.core.connection.JargonProperties;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.exception.OperationNotSupportedByThisServerException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Rule translator for Other rules (e.g. JSON for quotas)
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  */
 public class OtherRuleTranslator extends AbstractRuleTranslator {
 
-	Logger log = LoggerFactory.getLogger(this.getClass());
+	Logger log = LogManager.getLogger(this.getClass());
 
 	public OtherRuleTranslator(final IRODSServerProperties irodsServerProperties,
 			final RuleInvocationConfiguration ruleInvocationConfiguration, final JargonProperties jargonProperties) {

--- a/jargon-core/src/main/java/org/irods/jargon/core/rule/PythonRuleTranslator.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/rule/PythonRuleTranslator.java
@@ -12,8 +12,8 @@ import org.irods.jargon.core.connection.JargonProperties;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.exception.OperationNotSupportedByThisServerException;
 import org.irods.jargon.core.pub.RuleProcessingAO.RuleProcessingType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Rule translator for Python rules
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  */
 public class PythonRuleTranslator extends AbstractRuleTranslator {
 
-	Logger log = LoggerFactory.getLogger(this.getClass());
+	Logger log = LogManager.getLogger(this.getClass());
 
 	public PythonRuleTranslator(final IRODSServerProperties irodsServerProperties,
 			final RuleInvocationConfiguration ruleInvocationConfiguration, final JargonProperties jargonProperties) {

--- a/jargon-core/src/main/java/org/irods/jargon/core/rule/RuleEngineInstanceChooser.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/rule/RuleEngineInstanceChooser.java
@@ -5,8 +5,8 @@ package org.irods.jargon.core.rule;
 
 import org.irods.jargon.core.connection.IRODSServerProperties;
 import org.irods.jargon.core.connection.JargonProperties;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Utility to set the iRODS rule engine instance based on a provided rule as
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RuleEngineInstanceChooser {
 
-	private static final Logger log = LoggerFactory.getLogger(RuleEngineInstanceChooser.class);
+	private static final Logger log = LogManager.getLogger(RuleEngineInstanceChooser.class);
 	private final JargonProperties jargonProperties;
 	private final IRODSServerProperties irodsServerProperties;
 

--- a/jargon-core/src/main/java/org/irods/jargon/core/rule/RuleParsingUtils.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/rule/RuleParsingUtils.java
@@ -3,8 +3,8 @@
  */
 package org.irods.jargon.core.rule;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Utilities for parsing rules for processing by Jargon.
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
  */
 class RuleParsingUtils {
 
-	private static Logger log = LoggerFactory.getLogger(RuleParsingUtils.class);
+	private static Logger log = LogManager.getLogger(RuleParsingUtils.class);
 
 	/**
 	 * Private constructor

--- a/jargon-core/src/main/java/org/irods/jargon/core/rule/RuleTypeEvaluator.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/rule/RuleTypeEvaluator.java
@@ -7,8 +7,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.irods.jargon.core.utils.LocalFileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Tool to look at the contents of a rule and guess the language
@@ -22,7 +22,7 @@ public class RuleTypeEvaluator {
 	private final Pattern irodsRulePattern2;
 
 	private final Pattern pythonRulePattern;
-	private static final Logger log = LoggerFactory.getLogger(RuleTypeEvaluator.class);
+	private static final Logger log = LogManager.getLogger(RuleTypeEvaluator.class);
 
 	/**
 	 * annotation that can be added in a comment that can have a value of IRODS |

--- a/jargon-core/src/main/java/org/irods/jargon/core/security/IRODSPasswordUtilities.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/security/IRODSPasswordUtilities.java
@@ -11,8 +11,8 @@ import org.irods.jargon.core.connection.IRODSAccount;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.utils.Base64;
 import org.irods.jargon.core.utils.MiscIRODSUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Utilities for dealing with iRODS password (obfuscation, etc).
@@ -31,7 +31,7 @@ public class IRODSPasswordUtilities {
 	public static final String RAND_STRING_V2 = "A.ObfV2";
 	public static final int MAX_PWD_LENGTH = 50;
 
-	static final Logger log = LoggerFactory.getLogger(IRODSPasswordUtilities.class);
+	static final Logger log = LogManager.getLogger(IRODSPasswordUtilities.class);
 
 	static {
 

--- a/jargon-core/src/main/java/org/irods/jargon/core/transfer/AbstractNIOParallelTransferThread.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/transfer/AbstractNIOParallelTransferThread.java
@@ -6,8 +6,8 @@ import java.nio.channels.SocketChannel;
 
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.utils.Host;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Abstract superclasss for a parallel file transfer operation via NIO
@@ -26,7 +26,7 @@ public class AbstractNIOParallelTransferThread {
 	public static final int PUT_OPR = 1;
 	public static final int GET_OPR = 2;
 
-	public static final Logger log = LoggerFactory.getLogger(AbstractNIOParallelTransferThread.class);
+	public static final Logger log = LogManager.getLogger(AbstractNIOParallelTransferThread.class);
 
 	protected AbstractNIOParallelTransferThread() {
 		super();

--- a/jargon-core/src/main/java/org/irods/jargon/core/transfer/AbstractParallelCipherWrapper.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/transfer/AbstractParallelCipherWrapper.java
@@ -12,8 +12,8 @@ import org.irods.jargon.core.connection.NegotiatedClientServerConfiguration;
 import org.irods.jargon.core.connection.PipelineConfiguration;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.exception.JargonRuntimeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Wrapper for an implementation that can encrypt/decrypt bytes in a parallel
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  */
 abstract class AbstractParallelCipherWrapper {
 
-	public static final Logger log = LoggerFactory.getLogger(AbstractParallelCipherWrapper.class);
+	public static final Logger log = LogManager.getLogger(AbstractParallelCipherWrapper.class);
 
 	/**
 	 * @param pipelineConfiguration

--- a/jargon-core/src/main/java/org/irods/jargon/core/transfer/AbstractParallelFileTransferStrategy.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/transfer/AbstractParallelFileTransferStrategy.java
@@ -13,8 +13,8 @@ import org.irods.jargon.core.pub.IRODSAccessObjectFactory;
 import org.irods.jargon.core.transfer.encrypt.EncryptionWrapperFactory;
 import org.irods.jargon.core.transfer.encrypt.ParallelDecryptionCipherWrapper;
 import org.irods.jargon.core.transfer.encrypt.ParallelEncryptionCipherWrapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Abstract superclass for a parallel transfer controller. This will process
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractParallelFileTransferStrategy {
 
-	public static final Logger log = LoggerFactory.getLogger(AbstractParallelFileTransferStrategy.class);
+	public static final Logger log = LogManager.getLogger(AbstractParallelFileTransferStrategy.class);
 
 	public enum TransferType {
 		GET_TRANSFER, PUT_TRANSFER

--- a/jargon-core/src/main/java/org/irods/jargon/core/transfer/AbstractParallelTransferThread.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/transfer/AbstractParallelTransferThread.java
@@ -7,8 +7,8 @@ import java.net.Socket;
 
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.utils.Host;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Abstract superclasss for a parallel file transfer operation
@@ -32,7 +32,7 @@ public class AbstractParallelTransferThread {
 	 */
 	private final int threadNumber;
 
-	public static final Logger log = LoggerFactory.getLogger(AbstractParallelTransferThread.class);
+	public static final Logger log = LogManager.getLogger(AbstractParallelTransferThread.class);
 
 	protected AbstractParallelTransferThread(final int threadNumber) {
 		super();

--- a/jargon-core/src/main/java/org/irods/jargon/core/transfer/AbstractRestartManager.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/transfer/AbstractRestartManager.java
@@ -3,8 +3,8 @@
  */
 package org.irods.jargon.core.transfer;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Abstract superclass for a manager of file restarts. This allows in-memory,
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractRestartManager {
 
-	private static final Logger log = LoggerFactory.getLogger(AbstractRestartManager.class);
+	private static final Logger log = LogManager.getLogger(AbstractRestartManager.class);
 
 	/**
 	 * Either return existing, or create a new restart identifier

--- a/jargon-core/src/main/java/org/irods/jargon/core/transfer/AbstractTransferRestartProcessor.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/transfer/AbstractTransferRestartProcessor.java
@@ -11,8 +11,8 @@ import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.exception.JargonRuntimeException;
 import org.irods.jargon.core.pub.IRODSAccessObjectFactory;
 import org.irods.jargon.core.service.AbstractJargonService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * @author Mike Conway - (DICE) Restart processor abstract superclass. This
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractTransferRestartProcessor extends AbstractJargonService {
 
 	private final AbstractRestartManager restartManager;
-	private static Logger log = LoggerFactory.getLogger(AbstractTransferRestartProcessor.class);
+	private static Logger log = LogManager.getLogger(AbstractTransferRestartProcessor.class);
 	private final TransferStatusCallbackListener transferStatusCallbackListener;
 	private final TransferControlBlock transferControlBlock;
 

--- a/jargon-core/src/main/java/org/irods/jargon/core/transfer/DefaultTransferControlBlock.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/transfer/DefaultTransferControlBlock.java
@@ -2,8 +2,8 @@ package org.irods.jargon.core.transfer;
 
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.packinstr.TransferOptions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Default transfer control block that will by default return true for every
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DefaultTransferControlBlock implements TransferControlBlock {
 
-	private static final Logger log = LoggerFactory.getLogger(DefaultTransferControlBlock.class);
+	private static final Logger log = LogManager.getLogger(DefaultTransferControlBlock.class);
 
 	private String restartAbsolutePath = "";
 	private boolean cancelled = false;

--- a/jargon-core/src/main/java/org/irods/jargon/core/transfer/GetTransferRestartProcessor.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/transfer/GetTransferRestartProcessor.java
@@ -18,8 +18,8 @@ import org.irods.jargon.core.pub.IRODSAccessObjectFactory;
 import org.irods.jargon.core.pub.io.FileIOOperations.SeekWhenceType;
 import org.irods.jargon.core.pub.io.IRODSRandomAccessFile;
 import org.irods.jargon.core.transfer.TransferStatus.TransferType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Handle a restart of a get operation
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public class GetTransferRestartProcessor extends AbstractTransferRestartProcessor {
 
-	private static Logger log = LoggerFactory.getLogger(GetTransferRestartProcessor.class);
+	private static Logger log = LogManager.getLogger(GetTransferRestartProcessor.class);
 
 	/**
 	 * @param irodsAccessObjectFactory

--- a/jargon-core/src/main/java/org/irods/jargon/core/transfer/MemoryBasedTransferRestartManager.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/transfer/MemoryBasedTransferRestartManager.java
@@ -6,8 +6,8 @@ package org.irods.jargon.core.transfer;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.irods.jargon.core.connection.ConnectionConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Simple restart manager that exists in an in-memory map. This version is
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MemoryBasedTransferRestartManager extends AbstractRestartManager {
 
-	private static final Logger log = LoggerFactory.getLogger(MemoryBasedTransferRestartManager.class);
+	private static final Logger log = LogManager.getLogger(MemoryBasedTransferRestartManager.class);
 
 	private final ConcurrentHashMap<FileRestartInfoIdentifier, FileRestartInfo> cacheOfRestartInfo = new ConcurrentHashMap<FileRestartInfoIdentifier, FileRestartInfo>(
 			8, 0.9f, 1);

--- a/jargon-core/src/main/java/org/irods/jargon/core/transfer/ParallelGetFileTransferStrategy.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/transfer/ParallelGetFileTransferStrategy.java
@@ -15,8 +15,8 @@ import org.irods.jargon.core.connection.NegotiatedClientServerConfiguration;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.pub.DefaultIntraFileProgressCallbackListener;
 import org.irods.jargon.core.pub.IRODSAccessObjectFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Handle parallel file transfer get operation within Jargon. See
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class ParallelGetFileTransferStrategy extends AbstractParallelFileTransferStrategy {
 
-	public static final Logger log = LoggerFactory.getLogger(ParallelGetFileTransferStrategy.class);
+	public static final Logger log = LogManager.getLogger(ParallelGetFileTransferStrategy.class);
 
 	/**
 	 * Create an instance of a strategy to accomplish a parallel file transfer.

--- a/jargon-core/src/main/java/org/irods/jargon/core/transfer/ParallelGetTransferThread.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/transfer/ParallelGetTransferThread.java
@@ -18,8 +18,8 @@ import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.exception.JargonRuntimeException;
 import org.irods.jargon.core.transfer.encrypt.ParallelDecryptionCipherWrapper;
 import org.irods.jargon.core.utils.Host;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Handle parallel file transfer get operation within Jargon. See
@@ -39,7 +39,7 @@ public final class ParallelGetTransferThread extends AbstractParallelTransferThr
 	 */
 	private ParallelDecryptionCipherWrapper parallelDecryptionCipherWrapper;
 
-	public static final Logger log = LoggerFactory.getLogger(ParallelGetTransferThread.class);
+	public static final Logger log = LogManager.getLogger(ParallelGetTransferThread.class);
 
 	/**
 	 * Represents a thread used in a parallel file transfer. There will be multiple

--- a/jargon-core/src/main/java/org/irods/jargon/core/transfer/ParallelPutFileTransferStrategy.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/transfer/ParallelPutFileTransferStrategy.java
@@ -15,8 +15,8 @@ import org.irods.jargon.core.connection.NegotiatedClientServerConfiguration;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.pub.DefaultIntraFileProgressCallbackListener;
 import org.irods.jargon.core.pub.IRODSAccessObjectFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Strategy object for parallell put file transfer. This is an immutable object.
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class ParallelPutFileTransferStrategy extends AbstractParallelFileTransferStrategy {
 
-	public static final Logger log = LoggerFactory.getLogger(ParallelPutFileTransferStrategy.class);
+	public static final Logger log = LogManager.getLogger(ParallelPutFileTransferStrategy.class);
 
 	/**
 	 * Create an instance of a strategy to accomplish a parallel file transfer.

--- a/jargon-core/src/main/java/org/irods/jargon/core/transfer/ParallelPutTransferThread.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/transfer/ParallelPutTransferThread.java
@@ -16,8 +16,8 @@ import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.transfer.encrypt.EncryptionBuffer;
 import org.irods.jargon.core.transfer.encrypt.ParallelEncryptionCipherWrapper;
 import org.irods.jargon.core.utils.Host;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Handle parallel file transfer put operation, this is used within jargon.core,
@@ -35,7 +35,7 @@ public final class ParallelPutTransferThread extends AbstractParallelTransferThr
 	private RandomAccessFile localRandomAccessFile = null;
 	private ParallelEncryptionCipherWrapper parallelEncryptionCipherWrapper = null;
 
-	public static final Logger log = LoggerFactory.getLogger(ParallelPutTransferThread.class);
+	public static final Logger log = LogManager.getLogger(ParallelPutTransferThread.class);
 
 	/**
 	 * Represents a thread used in a parallel file transfer. There will be multiple

--- a/jargon-core/src/main/java/org/irods/jargon/core/transfer/PutTransferRestartProcessor.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/transfer/PutTransferRestartProcessor.java
@@ -18,15 +18,15 @@ import org.irods.jargon.core.pub.IRODSAccessObjectFactory;
 import org.irods.jargon.core.pub.io.FileIOOperations.SeekWhenceType;
 import org.irods.jargon.core.pub.io.IRODSRandomAccessFile;
 import org.irods.jargon.core.transfer.TransferStatus.TransferType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * @author Mike Conway - DICE
  */
 public class PutTransferRestartProcessor extends AbstractTransferRestartProcessor {
 
-	private static Logger log = LoggerFactory.getLogger(PutTransferRestartProcessor.class);
+	private static Logger log = LogManager.getLogger(PutTransferRestartProcessor.class);
 
 	/**
 	 * @param irodsAccessObjectFactory

--- a/jargon-core/src/main/java/org/irods/jargon/core/transfer/encrypt/AESKeyGenerator.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/transfer/encrypt/AESKeyGenerator.java
@@ -17,8 +17,8 @@ import org.irods.jargon.core.connection.NegotiatedClientServerConfiguration;
 import org.irods.jargon.core.connection.PipelineConfiguration;
 import org.irods.jargon.core.exception.EncryptionException;
 import org.irods.jargon.core.utils.RandomUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Generate an AES key based on pipeline config, assumes using salt and other
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AESKeyGenerator extends AbstractKeyGenerator {
 
-	public static final Logger log = LoggerFactory.getLogger(AESKeyGenerator.class);
+	public static final Logger log = LogManager.getLogger(AESKeyGenerator.class);
 
 	/**
 	 * @param pipelineConfiguration

--- a/jargon-core/src/main/java/org/irods/jargon/core/transfer/encrypt/AbstractKeyGenerator.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/transfer/encrypt/AbstractKeyGenerator.java
@@ -8,8 +8,8 @@ import javax.crypto.SecretKey;
 import org.irods.jargon.core.connection.NegotiatedClientServerConfiguration;
 import org.irods.jargon.core.connection.PipelineConfiguration;
 import org.irods.jargon.core.exception.EncryptionException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Abstract superclass for a shared encryption key generator implementation of a
@@ -23,7 +23,7 @@ public abstract class AbstractKeyGenerator {
 	private PipelineConfiguration pipelineConfiguration;
 	private NegotiatedClientServerConfiguration negotiatedClientServerConfiguration;
 
-	public static final Logger log = LoggerFactory.getLogger(AbstractKeyGenerator.class);
+	public static final Logger log = LogManager.getLogger(AbstractKeyGenerator.class);
 
 	protected PipelineConfiguration getPipelineConfiguration() {
 		return pipelineConfiguration;

--- a/jargon-core/src/main/java/org/irods/jargon/core/transfer/encrypt/AesCipherDecryptWrapper.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/transfer/encrypt/AesCipherDecryptWrapper.java
@@ -18,8 +18,8 @@ import org.irods.jargon.core.connection.NegotiatedClientServerConfiguration;
 import org.irods.jargon.core.connection.PipelineConfiguration;
 import org.irods.jargon.core.exception.ClientServerNegotiationException;
 import org.irods.jargon.core.exception.JargonRuntimeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Wraps decryption of a byte buffer using AES
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  */
 class AesCipherDecryptWrapper extends ParallelDecryptionCipherWrapper {
 
-	public static final Logger log = LoggerFactory.getLogger(AesCipherDecryptWrapper.class);
+	public static final Logger log = LogManager.getLogger(AesCipherDecryptWrapper.class);
 
 	/**
 	 * Default constructor with configuration information needed to set up the

--- a/jargon-core/src/main/java/org/irods/jargon/core/transfer/encrypt/AesCipherEncryptWrapper.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/transfer/encrypt/AesCipherEncryptWrapper.java
@@ -22,8 +22,8 @@ import org.irods.jargon.core.connection.PipelineConfiguration;
 import org.irods.jargon.core.exception.ClientServerNegotiationException;
 import org.irods.jargon.core.exception.EncryptionException;
 import org.irods.jargon.core.exception.JargonRuntimeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Wraps encryption of a byte buffer using AES
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 class AesCipherEncryptWrapper extends ParallelEncryptionCipherWrapper {
 
-	public static final Logger log = LoggerFactory.getLogger(AesCipherEncryptWrapper.class);
+	public static final Logger log = LogManager.getLogger(AesCipherEncryptWrapper.class);
 	public static byte[] ivPad = new byte[16];
 
 	/**

--- a/jargon-core/src/main/java/org/irods/jargon/core/transfer/encrypt/ParallelDecryptionCipherWrapper.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/transfer/encrypt/ParallelDecryptionCipherWrapper.java
@@ -6,8 +6,8 @@ package org.irods.jargon.core.transfer.encrypt;
 import org.irods.jargon.core.connection.NegotiatedClientServerConfiguration;
 import org.irods.jargon.core.connection.PipelineConfiguration;
 import org.irods.jargon.core.exception.EncryptionException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Wrapper for a cipher that will decrypt parallel transfer data
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class ParallelDecryptionCipherWrapper extends ParallelCipherWrapper {
 
-	public static final Logger log = LoggerFactory.getLogger(ParallelDecryptionCipherWrapper.class);
+	public static final Logger log = LogManager.getLogger(ParallelDecryptionCipherWrapper.class);
 
 	ParallelDecryptionCipherWrapper(final PipelineConfiguration pipelineConfiguration,
 			final NegotiatedClientServerConfiguration negotiatedClientServerConfiguration) {

--- a/jargon-core/src/main/java/org/irods/jargon/core/transfer/encrypt/ParallelEncryptionCipherWrapper.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/transfer/encrypt/ParallelEncryptionCipherWrapper.java
@@ -6,8 +6,8 @@ package org.irods.jargon.core.transfer.encrypt;
 import org.irods.jargon.core.connection.NegotiatedClientServerConfiguration;
 import org.irods.jargon.core.connection.PipelineConfiguration;
 import org.irods.jargon.core.exception.EncryptionException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Wrapper for a cipher that will encrypt parallel transfer data
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class ParallelEncryptionCipherWrapper extends ParallelCipherWrapper {
 
-	public static final Logger log = LoggerFactory.getLogger(ParallelEncryptionCipherWrapper.class);
+	public static final Logger log = LogManager.getLogger(ParallelEncryptionCipherWrapper.class);
 
 	ParallelEncryptionCipherWrapper(final PipelineConfiguration pipelineConfiguration,
 			final NegotiatedClientServerConfiguration negotiatedClientServerConfiguration) {

--- a/jargon-core/src/main/java/org/irods/jargon/core/utils/AccessObjectQueryProcessingUtils.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/utils/AccessObjectQueryProcessingUtils.java
@@ -13,8 +13,8 @@ import org.irods.jargon.core.query.IRODSQueryResultRow;
 import org.irods.jargon.core.query.IRODSQueryResultSetInterface;
 import org.irods.jargon.core.query.MetaDataAndDomainData;
 import org.irods.jargon.core.query.MetaDataAndDomainData.MetadataDomain;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Utility methods for processing various query operations for Jargon Access
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class AccessObjectQueryProcessingUtils {
-	private static Logger log = LoggerFactory.getLogger(AccessObjectQueryProcessingUtils.class);
+	private static Logger log = LogManager.getLogger(AccessObjectQueryProcessingUtils.class);
 
 	/**
 	 * @param resultSet

--- a/jargon-core/src/main/java/org/irods/jargon/core/utils/ChannelTools.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/utils/ChannelTools.java
@@ -5,15 +5,15 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * @author Mike Conway - DICE (www.irods.org)
  *
  */
 public final class ChannelTools {
-	private static final Logger log = LoggerFactory.getLogger(ChannelTools.class);
+	private static final Logger log = LogManager.getLogger(ChannelTools.class);
 
 	public static void fastChannelCopy(final ReadableByteChannel src, final WritableByteChannel dest,
 			final int bufferSize) throws IOException {

--- a/jargon-core/src/main/java/org/irods/jargon/core/utils/LocalFileUtils.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/utils/LocalFileUtils.java
@@ -26,8 +26,8 @@ import java.util.zip.CheckedInputStream;
 import org.apache.commons.codec.binary.Hex;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.pub.RuleProcessingAOImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Utilities for working with the local file system.
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 public class LocalFileUtils {
 
-	public static final Logger log = LoggerFactory.getLogger(LocalFileUtils.class);
+	public static final Logger log = LogManager.getLogger(LocalFileUtils.class);
 
 	/**
 	 * private constructor, this is not meant to be an instantiated class.

--- a/jargon-core/src/main/java/org/irods/jargon/core/utils/RestAuthUtils.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/utils/RestAuthUtils.java
@@ -7,8 +7,8 @@ import org.apache.commons.codec.binary.Base64;
 import org.irods.jargon.core.connection.AuthScheme;
 import org.irods.jargon.core.connection.IRODSAccount;
 import org.irods.jargon.core.exception.JargonException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Helpful utils for working with iRODS authentication in BasicAuthentication
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RestAuthUtils {
 
-	private static Logger log = LoggerFactory.getLogger(RestAuthUtils.class);
+	private static Logger log = LogManager.getLogger(RestAuthUtils.class);
 
 	/**
 	 * Given an {@link IRODSAccount} get the basic auth token value

--- a/jargon-core/src/main/java/org/irods/jargon/testutils/IRODSTestSetupUtilities.java
+++ b/jargon-core/src/main/java/org/irods/jargon/testutils/IRODSTestSetupUtilities.java
@@ -23,8 +23,8 @@ import org.irods.jargon.core.pub.IRODSFileSystem;
 import org.irods.jargon.core.pub.domain.AvuData;
 import org.irods.jargon.core.pub.io.IRODSFile;
 import org.irods.jargon.core.utils.Overheaded;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Common utilities to prep the test irods for unit tests
@@ -40,7 +40,7 @@ public class IRODSTestSetupUtilities {
 	private CollectionAO collectionAO;
 	private DataObjectAO dataObjectAO;
 
-	public static final Logger log = LoggerFactory.getLogger(IRODSTestSetupUtilities.class);
+	public static final Logger log = LogManager.getLogger(IRODSTestSetupUtilities.class);
 
 	public IRODSTestSetupUtilities() throws TestConfigurationException {
 		testingPropertiesHelper = new TestingPropertiesHelper();

--- a/jargon-core/src/main/java/org/irods/jargon/testutils/filemanip/FileGenerator.java
+++ b/jargon-core/src/main/java/org/irods/jargon/testutils/filemanip/FileGenerator.java
@@ -16,8 +16,8 @@ import java.util.Random;
 
 import org.irods.jargon.testutils.TestConfigurationException;
 import org.irods.jargon.testutils.TestingPropertiesHelper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Helper methods to generate dummy files and directories useful for Jargon
@@ -34,7 +34,7 @@ public class FileGenerator {
 	private static Properties testingProperties = new Properties();
 	private static TestingPropertiesHelper testingPropertiesHelper = new TestingPropertiesHelper();
 
-	private static Logger log = LoggerFactory.getLogger(FileGenerator.class);
+	private static Logger log = LogManager.getLogger(FileGenerator.class);
 
 	static {
 		fileExtensions.add(".doc");

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/AbstractDataUtilsServiceImpl.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/AbstractDataUtilsServiceImpl.java
@@ -3,12 +3,12 @@ package org.irods.jargon.datautils;
 import org.irods.jargon.core.connection.IRODSAccount;
 import org.irods.jargon.core.exception.JargonRuntimeException;
 import org.irods.jargon.core.pub.IRODSAccessObjectFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class AbstractDataUtilsServiceImpl implements DataUtilsService {
 
-	public static final Logger log = LoggerFactory.getLogger(AbstractDataUtilsServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(AbstractDataUtilsServiceImpl.class);
 	/**
 	 * Factory to create necessary Jargon access objects, which interact with the
 	 * iRODS server

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/avuautocomplete/AvuAutocompleteServiceImpl.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/avuautocomplete/AvuAutocompleteServiceImpl.java
@@ -17,8 +17,8 @@ import org.irods.jargon.core.query.JargonQueryException;
 import org.irods.jargon.core.query.QueryConditionOperators;
 import org.irods.jargon.core.query.RodsGenQueryEnum;
 import org.irods.jargon.core.service.AbstractJargonService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * @author Mike Conway - NIEHS
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AvuAutocompleteServiceImpl extends AbstractJargonService implements AvuAutocompleteService {
 
-	public static final Logger log = LoggerFactory.getLogger(AvuAutocompleteServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(AvuAutocompleteServiceImpl.class);
 
 	/**
 	 * @param irodsAccessObjectFactory

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/connection/ConnectionCreatingPoolableObjectFactory.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/connection/ConnectionCreatingPoolableObjectFactory.java
@@ -8,8 +8,8 @@ import org.irods.jargon.core.connection.IRODSMidLevelProtocol;
 import org.irods.jargon.core.connection.IRODSProtocolManager;
 import org.irods.jargon.core.connection.IRODSSession;
 import org.irods.jargon.core.connection.PipelineConfiguration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Factory for a pool-able object that is an iRODS connection. In the current
@@ -31,7 +31,7 @@ public class ConnectionCreatingPoolableObjectFactory implements PooledObjectFact
 	private final IRODSSession irodsSession;
 	private final PipelineConfiguration pipelineConfiguration;
 
-	private Logger log = LoggerFactory.getLogger(ConnectionCreatingPoolableObjectFactory.class);
+	private Logger log = LogManager.getLogger(ConnectionCreatingPoolableObjectFactory.class);
 
 	/**
 	 * Constructor will build a connection source based on the given

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/connection/TempPasswordCachingProtocolManager.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/connection/TempPasswordCachingProtocolManager.java
@@ -9,8 +9,8 @@ import org.irods.jargon.core.connection.IRODSSession;
 import org.irods.jargon.core.connection.PipelineConfiguration;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.exception.JargonRuntimeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Special variant of the {@link IRODSProtocolManager} that caches a temporary
@@ -28,7 +28,7 @@ public class TempPasswordCachingProtocolManager extends IRODSProtocolManager {
 
 	private GenericObjectPool<IRODSMidLevelProtocol> objectPool = null;
 
-	private final Logger log = LoggerFactory.getLogger(TempPasswordCachingProtocolManager.class);
+	private final Logger log = LogManager.getLogger(TempPasswordCachingProtocolManager.class);
 
 	/**
 	 *

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/connectiontester/ConnectionTesterImpl.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/connectiontester/ConnectionTesterImpl.java
@@ -21,8 +21,8 @@ import org.irods.jargon.core.pub.io.IRODSFile;
 import org.irods.jargon.core.service.AbstractJargonService;
 import org.irods.jargon.datautils.connectiontester.TestResultEntry.OperationType;
 import org.irods.jargon.testutils.TestConfigurationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * @author Mike Conway - DICE
@@ -32,7 +32,7 @@ public class ConnectionTesterImpl extends AbstractJargonService implements Conne
 
 	private static final Random RANDOM = new Random();
 
-	public static final Logger log = LoggerFactory.getLogger(ConnectionTesterImpl.class);
+	public static final Logger log = LogManager.getLogger(ConnectionTesterImpl.class);
 
 	private final ConnectionTesterConfiguration connectionTesterConfiguration;
 

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/datacache/CacheEncryptor.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/datacache/CacheEncryptor.java
@@ -13,12 +13,12 @@ import javax.crypto.spec.PBEParameterSpec;
 
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.exception.JargonRuntimeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class CacheEncryptor {
 
-	private static final Logger log = LoggerFactory.getLogger(CacheEncryptor.class);
+	private static final Logger log = LogManager.getLogger(CacheEncryptor.class);
 
 	Cipher ecipher;
 	Cipher dcipher;

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/datacache/DataCacheServiceImpl.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/datacache/DataCacheServiceImpl.java
@@ -15,8 +15,8 @@ import org.irods.jargon.core.pub.IRODSAccessObjectFactory;
 import org.irods.jargon.core.pub.Stream2StreamAO;
 import org.irods.jargon.core.pub.io.IRODSFile;
 import org.irods.jargon.datautils.AbstractDataUtilsServiceImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Service to provide a secure data cache. This allows information to be
@@ -37,7 +37,7 @@ public class DataCacheServiceImpl extends AbstractDataUtilsServiceImpl implement
 	 */
 	CacheServiceConfiguration cacheServiceConfiguration = new CacheServiceConfiguration();
 
-	public static final Logger log = LoggerFactory.getLogger(DataCacheServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(DataCacheServiceImpl.class);
 
 	/**
 	 * Constructor with required dependencies

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/datacache/NoEncryptDataCacheServiceImpl.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/datacache/NoEncryptDataCacheServiceImpl.java
@@ -16,8 +16,8 @@ import org.irods.jargon.core.pub.IRODSAccessObjectFactory;
 import org.irods.jargon.core.pub.Stream2StreamAO;
 import org.irods.jargon.core.pub.io.IRODSFile;
 import org.irods.jargon.datautils.AbstractDataUtilsServiceImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Service to provide an insecure data cache. The data in the cache is not
@@ -35,7 +35,7 @@ public class NoEncryptDataCacheServiceImpl extends AbstractDataUtilsServiceImpl 
 	 */
 	CacheServiceConfiguration cacheServiceConfiguration = new CacheServiceConfiguration();
 
-	public static final Logger log = LoggerFactory.getLogger(NoEncryptDataCacheServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(NoEncryptDataCacheServiceImpl.class);
 
 	/**
 	 * Constructor with required dependencies

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/filearchive/AbstractArchiver.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/filearchive/AbstractArchiver.java
@@ -10,8 +10,8 @@ import java.util.Iterator;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.irods.jargon.core.exception.JargonException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Superclass for a utility to create an archive from a directory (recursively)
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractArchiver {
 
-	public static final Logger log = LoggerFactory.getLogger(AbstractArchiver.class);
+	public static final Logger log = LogManager.getLogger(AbstractArchiver.class);
 
 	private final String sourceFileAbsolutePath;
 	private final String targetFileAbsolutePath;

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/filearchive/LocalFileGzipCompressor.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/filearchive/LocalFileGzipCompressor.java
@@ -18,8 +18,8 @@ import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.apache.commons.io.IOUtils;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.utils.LocalFileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Archiver that will tar a given local collection
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public class LocalFileGzipCompressor {
 
-	public static final Logger log = LoggerFactory.getLogger(LocalFileGzipCompressor.class);
+	public static final Logger log = LogManager.getLogger(LocalFileGzipCompressor.class);
 
 	/**
 	 *

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/filearchive/LocalTarFileArchiver.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/filearchive/LocalTarFileArchiver.java
@@ -17,8 +17,8 @@ import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.io.IOUtils;
 import org.irods.jargon.core.exception.JargonException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Archiver that will tar a given local collection
@@ -31,7 +31,7 @@ public class LocalTarFileArchiver extends AbstractArchiver {
 	private File tarArchiveFile = null;
 	private TarArchiveOutputStream tarArchiveOutputStream = null;
 
-	public static final Logger log = LoggerFactory.getLogger(LocalTarFileArchiver.class);
+	public static final Logger log = LogManager.getLogger(LocalTarFileArchiver.class);
 
 	/**
 	 * @param sourceFileAbsolutePath

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/filesampler/FileSamplerServiceImpl.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/filesampler/FileSamplerServiceImpl.java
@@ -19,8 +19,8 @@ import org.irods.jargon.core.pub.io.IRODSFile;
 import org.irods.jargon.core.pub.io.IRODSFileFactory;
 import org.irods.jargon.core.pub.io.IRODSFileReader;
 import org.irods.jargon.datautils.AbstractDataUtilsServiceImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Service to sample a given file for previews, file format recogntion, and the
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class FileSamplerServiceImpl extends AbstractDataUtilsServiceImpl implements FileSamplerService {
 
-	public static final Logger log = LoggerFactory.getLogger(FileSamplerServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(FileSamplerServiceImpl.class);
 
 	/**
 	 * @param irodsAccessObjectFactory

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/indexer/AbstractIndexerVisitor.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/indexer/AbstractIndexerVisitor.java
@@ -19,8 +19,8 @@ import org.irods.jargon.datautils.visitor.HierComponent;
 import org.irods.jargon.datautils.visitor.HierComposite;
 import org.irods.jargon.datautils.visitor.HierLeaf;
 import org.irods.jargon.datautils.visitor.IrodsVisitedComposite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Abstract superclass for a filtering, metadata aware visitor used for
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractIndexerVisitor extends AbstractIrodsVisitorComponent {
 
-	public static final Logger log = LoggerFactory.getLogger(AbstractIndexerVisitor.class);
+	public static final Logger log = LogManager.getLogger(AbstractIndexerVisitor.class);
 	private final CollectionAO collectionAO;
 	private final DataObjectAO dataObjectAO;
 	/**

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/indexer/ConfigurableIndexerFilter.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/indexer/ConfigurableIndexerFilter.java
@@ -6,8 +6,8 @@ package org.irods.jargon.datautils.indexer;
 import org.irods.jargon.core.query.MetaDataAndDomainData;
 import org.irods.jargon.datautils.visitor.HierComposite;
 import org.irods.jargon.datautils.visitor.HierLeaf;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Default indexer filter that in this implementation can be configured to index unless
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ConfigurableIndexerFilter implements IndexerFilterInterface {
 
-	public static final Logger log = LoggerFactory.getLogger(ConfigurableIndexerFilter.class);
+	public static final Logger log = LogManager.getLogger(ConfigurableIndexerFilter.class);
 
 	/**
 	 * Standard AVU attribute that permits indexing on a collection and children

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/indexer/IndexerServiceImpl.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/indexer/IndexerServiceImpl.java
@@ -10,8 +10,8 @@ import org.irods.jargon.core.pub.IRODSAccessObjectFactory;
 import org.irods.jargon.core.pub.io.IRODSFileImpl;
 import org.irods.jargon.core.service.AbstractJargonService;
 import org.irods.jargon.datautils.visitor.IrodsVisitedComposite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Service to run an indexer
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
  */
 public class IndexerServiceImpl extends AbstractJargonService {
 
-	public static final Logger log = LoggerFactory.getLogger(IndexerServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(IndexerServiceImpl.class);
 
 	/**
 	 * @param irodsAccessObjectFactory

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/metadatamanifest/MetadataManifestProcessorImpl.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/metadatamanifest/MetadataManifestProcessorImpl.java
@@ -19,8 +19,8 @@ import org.irods.jargon.core.pub.domain.AvuData;
 import org.irods.jargon.core.pub.domain.ObjStat;
 import org.irods.jargon.core.service.AbstractJargonService;
 import org.irods.jargon.datautils.metadatamanifest.MetadataManifest.FailureMode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -34,7 +34,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class MetadataManifestProcessorImpl extends AbstractJargonService implements MetadataManifestProcessor {
 
-	public static final Logger log = LoggerFactory.getLogger(MetadataManifestProcessorImpl.class);
+	public static final Logger log = LogManager.getLogger(MetadataManifestProcessorImpl.class);
 
 	/*
 	 * (non-Javadoc)

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/rule/UserRuleServiceImpl.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/rule/UserRuleServiceImpl.java
@@ -19,8 +19,8 @@ import org.irods.jargon.core.query.QueryConditionOperators;
 import org.irods.jargon.core.service.AbstractJargonService;
 import org.irods.jargon.core.utils.MiscIRODSUtils;
 import org.irods.jargon.datautils.rule.UserRuleDefinition.RuleAproposTo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Utilities to manage user defined rules in iRODS via a convention for a user
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class UserRuleServiceImpl extends AbstractJargonService implements UserRuleService {
 
-	public static final Logger log = LoggerFactory.getLogger(UserRuleServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(UserRuleServiceImpl.class);
 
 	private static final String USER_RULE_UNIT = "iRODSUserTagging:UserRule";
 

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/shoppingcart/ShoppingCartServiceImpl.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/shoppingcart/ShoppingCartServiceImpl.java
@@ -12,8 +12,8 @@ import org.irods.jargon.datautils.AbstractDataUtilsServiceImpl;
 import org.irods.jargon.datautils.datacache.CacheServiceConfiguration;
 import org.irods.jargon.datautils.datacache.DataCacheService;
 import org.irods.jargon.datautils.datacache.DataCacheServiceFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Service for general shopping cart handling, including capability to cache the
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ShoppingCartServiceImpl extends AbstractDataUtilsServiceImpl implements ShoppingCartService {
 
-	public static final Logger log = LoggerFactory.getLogger(ShoppingCartServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(ShoppingCartServiceImpl.class);
 
 	/**
 	 * Factory for {@code DataCacheService} creation, must be set via constructor or

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/synchproperties/SynchPropertiesServiceImpl.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/synchproperties/SynchPropertiesServiceImpl.java
@@ -19,8 +19,8 @@ import org.irods.jargon.core.query.JargonQueryException;
 import org.irods.jargon.core.query.MetaDataAndDomainData;
 import org.irods.jargon.core.query.QueryConditionOperators;
 import org.irods.jargon.datautils.AbstractDataUtilsServiceImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Service to maintain synchronization properties for client to iRODS data
@@ -40,7 +40,7 @@ public class SynchPropertiesServiceImpl extends AbstractDataUtilsServiceImpl imp
 	 * iRODSSynch:userSynchDir
 	 */
 
-	public static final Logger log = LoggerFactory.getLogger(SynchPropertiesServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(SynchPropertiesServiceImpl.class);
 
 	/**
 	 *

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/tree/DiffTreePostProcessor.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/tree/DiffTreePostProcessor.java
@@ -7,8 +7,8 @@ import java.util.Enumeration;
 
 import javax.swing.tree.TreeNode;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Post-processor for a diff tree will roll up counts of diffs in children and
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DiffTreePostProcessor {
 
-	private static Logger log = LoggerFactory.getLogger(DiffTreePostProcessor.class);
+	private static Logger log = LogManager.getLogger(DiffTreePostProcessor.class);
 
 	/**
 	 *

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/tree/FileTreeDiffUtilityImpl.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/tree/FileTreeDiffUtilityImpl.java
@@ -24,8 +24,8 @@ import org.irods.jargon.core.utils.LocalFileUtils;
 import org.irods.jargon.datautils.AbstractDataUtilsServiceImpl;
 import org.irods.jargon.datautils.tree.FileOrDirFilter.FilterFor;
 import org.irods.jargon.datautils.tree.FileTreeDiffEntry.DiffType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Utility to create a diff between two file trees. These trees may be either
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 public class FileTreeDiffUtilityImpl extends AbstractDataUtilsServiceImpl implements FileTreeDiffUtility {
 
-	private static Logger log = LoggerFactory.getLogger(FileTreeDiffUtilityImpl.class);
+	private static Logger log = LogManager.getLogger(FileTreeDiffUtilityImpl.class);
 
 	private DataObjectChecksumUtilitiesAO dataObjectChecksumUtilitiesAO;
 

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/visitor/HierVisitorCrawlerServiceImpl.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/visitor/HierVisitorCrawlerServiceImpl.java
@@ -9,8 +9,8 @@ import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.pub.IRODSAccessObjectFactory;
 import org.irods.jargon.core.pub.io.IRODSFileImpl;
 import org.irods.jargon.core.service.AbstractJargonService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Service to run a crawl given a visitor and configuration. This is an example
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HierVisitorCrawlerServiceImpl extends AbstractJargonService {
 
-	public static final Logger log = LoggerFactory.getLogger(HierVisitorCrawlerServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(HierVisitorCrawlerServiceImpl.class);
 
 	/**
 	 * @param irodsAccessObjectFactory

--- a/jargon-data-utils/src/main/java/org/irods/jargon/datautils/visitor/IrodsVisitedComposite.java
+++ b/jargon-data-utils/src/main/java/org/irods/jargon/datautils/visitor/IrodsVisitedComposite.java
@@ -8,8 +8,8 @@ import java.io.File;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.pub.IRODSFileSystemAO;
 import org.irods.jargon.core.pub.io.IRODSFileImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Concrete implementation of an iRODS directory as visited by a hierarchical
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
  */
 public class IrodsVisitedComposite extends IrodsFileItem implements HierComposite {
 
-	public static final Logger log = LoggerFactory.getLogger(IrodsVisitedComposite.class);
+	public static final Logger log = LogManager.getLogger(IrodsVisitedComposite.class);
 
 	private static final long serialVersionUID = 2022187755904761797L;
 

--- a/jargon-mdquery/src/main/java/org/irods/jargon/mdquery/serialization/MetadataQueryJsonService.java
+++ b/jargon-mdquery/src/main/java/org/irods/jargon/mdquery/serialization/MetadataQueryJsonService.java
@@ -8,8 +8,8 @@ import java.io.IOException;
 import org.irods.jargon.mdquery.MetadataQuery;
 import org.irods.jargon.mdquery.exception.MetadataQueryException;
 import org.irods.jargon.mdquery.exception.MetadataQueryRuntimeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class MetadataQueryJsonService {
 
-	public static final Logger log = LoggerFactory.getLogger(MetadataQueryJsonService.class);
+	public static final Logger log = LogManager.getLogger(MetadataQueryJsonService.class);
 
 	private final ObjectMapper objectMapper;
 

--- a/jargon-mdquery/src/main/java/org/irods/jargon/mdquery/service/MetadataQueryServiceImpl.java
+++ b/jargon-mdquery/src/main/java/org/irods/jargon/mdquery/service/MetadataQueryServiceImpl.java
@@ -31,8 +31,8 @@ import org.irods.jargon.mdquery.MetadataQuery.QueryType;
 import org.irods.jargon.mdquery.MetadataQueryElement;
 import org.irods.jargon.mdquery.exception.MetadataQueryException;
 import org.irods.jargon.mdquery.serialization.MetadataQueryJsonService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Implementation of a service to generate metadata queries on iRODS. These are
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MetadataQueryServiceImpl extends AbstractJargonService implements MetadataQueryService {
 
-	static Logger log = LoggerFactory.getLogger(MetadataQueryServiceImpl.class);
+	static Logger log = LogManager.getLogger(MetadataQueryServiceImpl.class);
 
 	/**
 	 * Constructor takes dependencies

--- a/jargon-pool/src/main/java/org/irods/jargon/pool/conncache/CachedIrodsProtocolManager.java
+++ b/jargon-pool/src/main/java/org/irods/jargon/pool/conncache/CachedIrodsProtocolManager.java
@@ -10,8 +10,8 @@ import org.irods.jargon.core.connection.IRODSSession;
 import org.irods.jargon.core.connection.PipelineConfiguration;
 import org.irods.jargon.core.exception.AuthenticationException;
 import org.irods.jargon.core.exception.JargonException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * @author mconway
@@ -24,7 +24,7 @@ public class CachedIrodsProtocolManager extends IRODSProtocolManager {
 	 */
 	private JargonConnectionCache jargonConnectionCache;
 
-	private Logger log = LoggerFactory.getLogger(CachedIrodsProtocolManager.class);
+	private Logger log = LogManager.getLogger(CachedIrodsProtocolManager.class);
 
 	/**
 	 *

--- a/jargon-pool/src/main/java/org/irods/jargon/pool/conncache/JargonConnectionCache.java
+++ b/jargon-pool/src/main/java/org/irods/jargon/pool/conncache/JargonConnectionCache.java
@@ -7,8 +7,8 @@ import org.apache.commons.pool2.KeyedPooledObjectFactory;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
 import org.irods.jargon.core.connection.IRODSAccount;
 import org.irods.jargon.core.connection.IRODSMidLevelProtocol;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Connection cache keeps a pool of managed iRODS connections
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
  */
 public class JargonConnectionCache extends GenericKeyedObjectPool<IRODSAccount, IRODSMidLevelProtocol> {
 
-	public static final Logger log = LoggerFactory.getLogger(JargonPooledObjectFactory.class);
+	public static final Logger log = LogManager.getLogger(JargonPooledObjectFactory.class);
 
 	public JargonConnectionCache(final KeyedPooledObjectFactory<IRODSAccount, IRODSMidLevelProtocol> factory,
 			final JargonKeyedPoolConfig config) {

--- a/jargon-pool/src/main/java/org/irods/jargon/pool/conncache/JargonPooledObjectFactory.java
+++ b/jargon-pool/src/main/java/org/irods/jargon/pool/conncache/JargonPooledObjectFactory.java
@@ -8,8 +8,8 @@ import org.irods.jargon.core.connection.IRODSMidLevelProtocol;
 import org.irods.jargon.core.connection.IRODSProtocolManager;
 import org.irods.jargon.core.connection.IRODSSession;
 import org.irods.jargon.core.connection.IRODSSimpleProtocolManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Factory for pooled iRODS connections. Note that the key of the pool is the
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  */
 public class JargonPooledObjectFactory extends BaseKeyedPooledObjectFactory<IRODSAccount, IRODSMidLevelProtocol> {
 
-	public static final Logger log = LoggerFactory.getLogger(JargonPooledObjectFactory.class);
+	public static final Logger log = LogManager.getLogger(JargonPooledObjectFactory.class);
 
 	/**
 	 * Expected injected dependency {@link IRODSSimpleProtocolManager} that will be

--- a/jargon-ruleservice/src/main/java/org/irods/jargon/ruleservice/composition/RuleCompositionServiceImpl.java
+++ b/jargon-ruleservice/src/main/java/org/irods/jargon/ruleservice/composition/RuleCompositionServiceImpl.java
@@ -26,8 +26,8 @@ import org.irods.jargon.core.rule.IRODSRuleParameter;
 import org.irods.jargon.core.rule.IrodsRuleEngineRuleTranslator;
 import org.irods.jargon.core.rule.RuleInvocationConfiguration;
 import org.irods.jargon.core.service.AbstractJargonService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Service implementation to support composition of rules
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RuleCompositionServiceImpl extends AbstractJargonService implements RuleCompositionService {
 
-	public static final Logger log = LoggerFactory.getLogger(RuleCompositionServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(RuleCompositionServiceImpl.class);
 
 	/*
 	 * (non-Javadoc)

--- a/jargon-ticket/src/main/java/org/irods/jargon/ticket/TicketAdminServiceImpl.java
+++ b/jargon-ticket/src/main/java/org/irods/jargon/ticket/TicketAdminServiceImpl.java
@@ -36,8 +36,8 @@ import org.irods.jargon.ticket.packinstr.TicketCreateModeEnum;
 import org.irods.jargon.ticket.packinstr.TicketInp;
 import org.irods.jargon.ticket.packinstr.TicketModifyAddOrRemoveTypeEnum;
 import org.irods.jargon.ticket.utils.TicketRandomString;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public final class TicketAdminServiceImpl extends AbstractTicketService implements TicketAdminService {
 
@@ -46,7 +46,7 @@ public final class TicketAdminServiceImpl extends AbstractTicketService implemen
 	private static final String COMMA_SPACE = ", ";
 	private static final String ERROR_IN_TICKET_QUERY = "error in ticket query";
 	private static final String TICKET_NOT_FOUND = "IRODS ticket not found";
-	public static final Logger log = LoggerFactory.getLogger(TicketAdminServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(TicketAdminServiceImpl.class);
 	private final EnvironmentalInfoAO environmentalInfAO;
 
 	/**

--- a/jargon-ticket/src/main/java/org/irods/jargon/ticket/TicketClientOperationsImpl.java
+++ b/jargon-ticket/src/main/java/org/irods/jargon/ticket/TicketClientOperationsImpl.java
@@ -18,8 +18,8 @@ import org.irods.jargon.core.transfer.TransferControlBlock;
 import org.irods.jargon.core.transfer.TransferStatusCallbackListener;
 import org.irods.jargon.ticket.io.CleanUpWhenClosedInputStream;
 import org.irods.jargon.ticket.io.FileStreamAndInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Client transfer and other operations that are ticket enabled, wrapped with
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TicketClientOperationsImpl extends AbstractTicketService implements TicketClientOperations {
 
-	public static final Logger log = LoggerFactory.getLogger(TicketClientOperationsImpl.class);
+	public static final Logger log = LogManager.getLogger(TicketClientOperationsImpl.class);
 
 	private DataTransferOperations dataTransferOperations = null;
 	private TicketClientSupport ticketClientSupport = null;

--- a/jargon-ticket/src/main/java/org/irods/jargon/ticket/TicketClientSupport.java
+++ b/jargon-ticket/src/main/java/org/irods/jargon/ticket/TicketClientSupport.java
@@ -5,12 +5,12 @@ import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.packinstr.Tag;
 import org.irods.jargon.core.pub.IRODSAccessObjectFactory;
 import org.irods.jargon.ticket.packinstr.TicketInp;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class TicketClientSupport {
 
-	public static final Logger log = LoggerFactory.getLogger(TicketClientSupport.class);
+	public static final Logger log = LogManager.getLogger(TicketClientSupport.class);
 
 	private final IRODSAccessObjectFactory irodsAccessObjectFactory;
 	private final IRODSAccount irodsAccount;

--- a/jargon-ticket/src/main/java/org/irods/jargon/ticket/TicketDistributionServiceImpl.java
+++ b/jargon-ticket/src/main/java/org/irods/jargon/ticket/TicketDistributionServiceImpl.java
@@ -9,8 +9,8 @@ import org.irods.jargon.core.connection.IRODSAccount;
 import org.irods.jargon.core.exception.JargonException;
 import org.irods.jargon.core.pub.IRODSAccessObjectFactory;
 import org.irods.jargon.core.utils.IRODSUriUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Service to assist in the distribution of tickets. This is meant to provide
@@ -32,7 +32,7 @@ public class TicketDistributionServiceImpl extends AbstractTicketService impleme
 	private final TicketServiceFactory ticketServiceFactory;
 	private final TicketDistributionContext ticketDistributionContext;
 
-	public static final Logger log = LoggerFactory.getLogger(TicketDistributionServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(TicketDistributionServiceImpl.class);
 
 	/**
 	 * Default constructor takes the objects necessary to communicate with iRODS via

--- a/jargon-user-tagging/src/main/java/org/irods/jargon/usertagging/sharing/IRODSSharingServiceImpl.java
+++ b/jargon-user-tagging/src/main/java/org/irods/jargon/usertagging/sharing/IRODSSharingServiceImpl.java
@@ -35,8 +35,8 @@ import org.irods.jargon.usertagging.AbstractIRODSTaggingService;
 import org.irods.jargon.usertagging.domain.IRODSSharedFileOrCollection;
 import org.irods.jargon.usertagging.domain.ShareUser;
 import org.irods.jargon.usertagging.tags.UserTaggingConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * A service to share Collections and Data Objects
@@ -69,7 +69,7 @@ import org.slf4j.LoggerFactory;
  */
 public class IRODSSharingServiceImpl extends AbstractIRODSTaggingService implements IRODSSharingService {
 
-	public static final Logger log = LoggerFactory.getLogger(IRODSSharingServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(IRODSSharingServiceImpl.class);
 
 	/**
 	 * @param irodsAccessObjectFactory

--- a/jargon-user-tagging/src/main/java/org/irods/jargon/usertagging/starring/IRODSStarringServiceImpl.java
+++ b/jargon-user-tagging/src/main/java/org/irods/jargon/usertagging/starring/IRODSStarringServiceImpl.java
@@ -28,8 +28,8 @@ import org.irods.jargon.core.utils.MiscIRODSUtils;
 import org.irods.jargon.usertagging.AbstractIRODSTaggingService;
 import org.irods.jargon.usertagging.domain.IRODSStarredFileOrCollection;
 import org.irods.jargon.usertagging.tags.UserTaggingConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * A service to star or favorite files or folders
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  */
 public class IRODSStarringServiceImpl extends AbstractIRODSTaggingService implements IRODSStarringService {
 
-	public static final Logger log = LoggerFactory.getLogger(IRODSStarringServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(IRODSStarringServiceImpl.class);
 
 	/**
 	 * @param irodsAccessObjectFactory

--- a/jargon-user-tagging/src/main/java/org/irods/jargon/usertagging/tags/FreeTaggingServiceImpl.java
+++ b/jargon-user-tagging/src/main/java/org/irods/jargon/usertagging/tags/FreeTaggingServiceImpl.java
@@ -28,8 +28,8 @@ import org.irods.jargon.usertagging.AbstractIRODSTaggingService;
 import org.irods.jargon.usertagging.domain.IRODSTagGrouping;
 import org.irods.jargon.usertagging.domain.IRODSTagValue;
 import org.irods.jargon.usertagging.domain.TagQuerySearchResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * This object is a bridge between the typical user interface depiction of tags
@@ -51,7 +51,7 @@ public final class FreeTaggingServiceImpl extends AbstractIRODSTaggingService im
 	public final String EQUALS_QUOTE = " = '";
 	public final char QUOTE = '\'';
 
-	public static final Logger log = LoggerFactory.getLogger(FreeTaggingServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(FreeTaggingServiceImpl.class);
 
 	private final IRODSTaggingService irodsTaggingService;
 

--- a/jargon-user-tagging/src/main/java/org/irods/jargon/usertagging/tags/IRODSTaggingServiceImpl.java
+++ b/jargon-user-tagging/src/main/java/org/irods/jargon/usertagging/tags/IRODSTaggingServiceImpl.java
@@ -24,8 +24,8 @@ import org.irods.jargon.core.query.MetaDataAndDomainData.MetadataDomain;
 import org.irods.jargon.core.query.QueryConditionOperators;
 import org.irods.jargon.usertagging.AbstractIRODSTaggingService;
 import org.irods.jargon.usertagging.domain.IRODSTagValue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Service for processing IRODS free tags. This method provides services on top
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class IRODSTaggingServiceImpl extends AbstractIRODSTaggingService implements IRODSTaggingService {
 
-	public static final Logger log = LoggerFactory.getLogger(IRODSTaggingServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(IRODSTaggingServiceImpl.class);
 
 	/**
 	 * Static initializer used to create instances of the service.

--- a/jargon-user-tagging/src/main/java/org/irods/jargon/usertagging/tags/UserTagCloudServiceImpl.java
+++ b/jargon-user-tagging/src/main/java/org/irods/jargon/usertagging/tags/UserTagCloudServiceImpl.java
@@ -20,8 +20,8 @@ import org.irods.jargon.usertagging.AbstractIRODSTaggingService;
 import org.irods.jargon.usertagging.domain.IRODSTagValue;
 import org.irods.jargon.usertagging.domain.TagCloudEntry;
 import org.irods.jargon.usertagging.domain.UserTagCloudView;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Service for query and processing of a user tag cloud.
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class UserTagCloudServiceImpl extends AbstractIRODSTaggingService implements UserTagCloudService {
 
-	public static final Logger log = LoggerFactory.getLogger(UserTagCloudServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(UserTagCloudServiceImpl.class);
 
 	public static final String COMMA_SPACE = ", ";
 	public static final String EQUAL_QUOTE = " = '";

--- a/jargon-zipservice/src/main/java/org/irods/jargon/zipservice/api/JargonZipServiceImpl.java
+++ b/jargon-zipservice/src/main/java/org/irods/jargon/zipservice/api/JargonZipServiceImpl.java
@@ -24,8 +24,8 @@ import org.irods.jargon.core.transfer.TransferControlBlock;
 import org.irods.jargon.core.utils.MiscIRODSUtils;
 import org.irods.jargon.zipservice.api.exception.ZipServiceConfigurationException;
 import org.irods.jargon.zipservice.api.exception.ZipServiceException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Abstract service to handle zipping and transferring a set of iRODS paths as
@@ -39,7 +39,7 @@ public class JargonZipServiceImpl extends AbstractJargonService implements Jargo
 	private ZipServiceConfiguration zipServiceConfiguration = null;
 	private final Random random;
 
-	public static final Logger log = LoggerFactory.getLogger(JargonZipServiceImpl.class);
+	public static final Logger log = LogManager.getLogger(JargonZipServiceImpl.class);
 
 	public JargonZipServiceImpl() {
 		super();

--- a/pom.xml
+++ b/pom.xml
@@ -77,17 +77,8 @@
 	</distributionManagement>
 	<dependencies>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-				 <groupId>org.apache.logging.log4j</groupId>
-				 <artifactId>log4j-core</artifactId>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>


### PR DESCRIPTION
This PR updates log4j to 2.x and removes slf4j as a dependency.

Jargon now compiles against the log4j 2 API only. That means Jargon no longer defines a default logging implementation. Users of the library can add log4j-core to their pom.xml file to get an implementation.

Confirmed this works with small test application, but still need to run against full test suite.

Will take out of draft once I've confirmed everything works.