### PR TITLE
Do not interpret RError stack messages as errors (master)

### DIFF
--- a/docker-test-framework/4-3/docker-compose.yml
+++ b/docker-test-framework/4-3/docker-compose.yml
@@ -5,7 +5,7 @@ services:
         context: .
         dockerfile: Dockerfile.provider
         args:
-            irods_package_version: 4.3.3-0~jammy
+            irods_package_version: 4.3.4-0~jammy
     hostname: icat.example.org
     healthcheck:
       test: ["CMD", "su", "-", "irods", "-c", "ils"]
@@ -29,7 +29,7 @@ services:
         context: .
         dockerfile: Dockerfile.consumer
         args:
-            irods_package_version: 4.3.3-0~jammy
+            irods_package_version: 4.3.4-0~jammy
     hostname: resource1.example.org
     networks:
       irodsnet:

--- a/docker-test-framework/4-3/testsetup-consortium.sh
+++ b/docker-test-framework/4-3/testsetup-consortium.sh
@@ -29,3 +29,5 @@ iadmin atg jargonTestUg test1
 
 iadmin atg jargonTestUg test3
 
+# iRODS 4.3.4 made the hello script a template. Restore it to avoid test failures.
+[ -f /var/lib/irods/msiExecCmd_bin/hello.template ] && cp /var/lib/irods/msiExecCmd_bin/hello.template /var/lib/irods/msiExecCmd_bin/hello

--- a/jargon-core/src/main/java/org/irods/jargon/core/connection/IRODSMidLevelProtocol.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/connection/IRODSMidLevelProtocol.java
@@ -1129,7 +1129,7 @@ public class IRODSMidLevelProtocol {
 		// previous will have returned or thrown exception
 
 		if (errorLength != 0) {
-			return processMessageErrorNotEqualZero(errorLength);
+			processMessageErrorNotEqualZero(errorLength);
 		}
 
 		if (bytesLength != 0 || info > 0) {
@@ -1509,7 +1509,7 @@ public class IRODSMidLevelProtocol {
 		}
 	}
 
-	Tag processMessageErrorNotEqualZero(final int errorLength) throws JargonException {
+	void processMessageErrorNotEqualZero(final int errorLength) throws JargonException {
 		log.debug("error length is not zero, process error");
 		byte[] errorMessage = new byte[errorLength];
 		try {
@@ -1550,15 +1550,12 @@ public class IRODSMidLevelProtocol {
 			log.debug("error status of 0 indicates normal operation, ignored");
 			String errorText = errorTag.getTag(RErrMsg.PI_TAG).getTag(IRodsPI.MESSAGE_TAG).getStringValue();
 			log.debug("error tag contents:{}", errorText);
-			return errorPITag;
 		}
 
 		String errorText = errorTag.getTag(RErrMsg.PI_TAG).getTag(IRodsPI.MESSAGE_TAG).getStringValue();
 
 		log.error("IRODS error encountered:{}", errorText);
 		log.error("status from error is:{}", statusVal);
-
-		throw new JargonException("error returned from iRODS, status = " + statusVal + " message:" + errorText);
 	}
 
 	/*

--- a/jargon-core/src/main/java/org/irods/jargon/core/pub/RuleProcessingAOImpl.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/pub/RuleProcessingAOImpl.java
@@ -395,17 +395,14 @@ public final class RuleProcessingAOImpl extends IRODSGenericAO implements RulePr
 		ExecMyRuleInp execMyRuleInp = ExecMyRuleInp.instanceForListAvailableRuleEngines();
 		final Tag response = getIRODSProtocol().irodsFunction(execMyRuleInp);
 		log.debug("response from rule exec: {}", response.parseTag());
-		/*
-		 * For some reason this operation returns the list of rule engines as an error
-		 * response, so that tag is shoved back into the response and I will need to
-		 * parse it here
-		 */
-		if (!response.getName().equals("RErrMsg_PI")) {
-			log.error("did not get RErrMsg_PI from list rule engines");
+
+		if (!response.getName().equals("RError_PI")) {
+			log.error("did not get RError_PI from list rule engines");
 			throw new JargonRuntimeException("unexpected protocol response encountered when listing rule engines");
 		}
 
-		String message = response.getTag("msg").getStringValue();
+		Tag rErrMsg = response.getTag("RErrMsg_PI");
+		String message = rErrMsg.getTag("msg").getStringValue();
 		log.info("rule listing tag response:{}", message);
 		List<String> ruleEngines = new ArrayList<String>();
 

--- a/jargon-core/src/test/java/org/irods/jargon/core/pub/CollectionAOImplTest.java
+++ b/jargon-core/src/test/java/org/irods/jargon/core/pub/CollectionAOImplTest.java
@@ -699,7 +699,8 @@ public class CollectionAOImplTest {
 		listOfAvuData.add(AvuData.instance(expectedAttribName, expectedAttribValue, ""));
 		listOfAvuData.add(AvuData.instance(expectedAttribName, expectedAttribValue, ""));
 
-		if (accessObjectFactory.getIRODSServerProperties(irodsAccount).isAtLeastIrods431()) {
+		IRODSServerProperties svrProps = accessObjectFactory.getIRODSServerProperties(irodsAccount);
+		if (svrProps.isAtLeastIrods431() && !svrProps.isTheIrodsServerAtLeastAtTheGivenReleaseVersion("rods4.3.4")) {
 			Assert.assertThrows(CatalogSQLException.class,
 					() -> collectionAO.addBulkAVUMetadataToCollection(targetIrodsCollection, listOfAvuData));
 		} else {
@@ -846,7 +847,10 @@ public class CollectionAOImplTest {
 		AvuData dataToAdd = AvuData.instance(expectedAttribName, expectedAttribValue, "");
 		collectionAO.addAVUMetadata(targetIrodsCollection, dataToAdd);
 
-		if (accessObjectFactory.getIRODSServerProperties(irodsAccount).isAtLeastIrods431()) {
+		if (accessObjectFactory.getIRODSServerProperties(irodsAccount).isTheIrodsServerAtLeastAtTheGivenReleaseVersion("rods4.3.4")) {
+			Assert.assertThrows(DuplicateDataException.class,
+					() -> collectionAO.addAVUMetadata(targetIrodsCollection, dataToAdd));
+		} else if (accessObjectFactory.getIRODSServerProperties(irodsAccount).isAtLeastIrods431()) {
 			Assert.assertThrows(CatalogSQLException.class,
 					() -> collectionAO.addAVUMetadata(targetIrodsCollection, dataToAdd));
 		} else {

--- a/jargon-core/src/test/java/org/irods/jargon/core/pub/DataObjectAOImplTest.java
+++ b/jargon-core/src/test/java/org/irods/jargon/core/pub/DataObjectAOImplTest.java
@@ -2840,7 +2840,10 @@ public class DataObjectAOImplTest {
 		DataObjectAO dataObjectAO = irodsFileSystem.getIRODSAccessObjectFactory().getDataObjectAO(irodsAccount);
 		dataObjectAO.addAVUMetadata(targetIrodsDataObject, avuData);
 
-		if (accessObjectFactory.getIRODSServerProperties(irodsAccount).isAtLeastIrods431()) {
+		if (accessObjectFactory.getIRODSServerProperties(irodsAccount).isTheIrodsServerAtLeastAtTheGivenReleaseVersion("rods4.3.4")) {
+			Assert.assertThrows(DuplicateDataException.class,
+					() -> dataObjectAO.addAVUMetadata(targetIrodsDataObject, avuData));
+		} else if (accessObjectFactory.getIRODSServerProperties(irodsAccount).isAtLeastIrods431()) {
 			Assert.assertThrows(CatalogSQLException.class,
 					() -> dataObjectAO.addAVUMetadata(targetIrodsDataObject, avuData));
 		} else {

--- a/jargon-core/src/test/java/org/irods/jargon/core/pub/UserAOTest.java
+++ b/jargon-core/src/test/java/org/irods/jargon/core/pub/UserAOTest.java
@@ -1043,7 +1043,10 @@ public class UserAOTest {
 		try {
 			userAO.addAVUMetadata(irodsAccount.getUserName(), avuData);
 
-			if (accessObjectFactory.getIRODSServerProperties(irodsAccount).isAtLeastIrods431()) {
+			if (accessObjectFactory.getIRODSServerProperties(irodsAccount).isTheIrodsServerAtLeastAtTheGivenReleaseVersion("rods4.3.4")) {
+				Assert.assertThrows(DuplicateDataException.class,
+						() -> userAO.addAVUMetadata(irodsAccount.getUserName(), avuData));
+			} else if (accessObjectFactory.getIRODSServerProperties(irodsAccount).isAtLeastIrods431()) {
 				Assert.assertThrows(CatalogSQLException.class,
 						() -> userAO.addAVUMetadata(irodsAccount.getUserName(), avuData));
 			} else {


### PR DESCRIPTION
This is in service of https://github.com/irods-contrib/metalnx-web/issues/402.

The issue reported in Metalnx is reproducible with Jargon. This PR resolves that and also introduces support for testing against iRODS 5.

Here are the test results using the new iRODS 5 container.
```
[INFO]                                                                                                                                                                                                                                                                                                                                                                             [48/42721]
[INFO] Results:                                                                                
[INFO]                                                                                                                                                                                        
[ERROR] Failures:                                                                              
[ERROR]   CollectionAOImplTest.testAddDuplicateAvuMetadata:850 unexpected exception type thrown; expected:<org.irods.jargon.core.exception.CatalogSQLException> but was:<org.irods.jargon.core.exception.DuplicateDataException>
[ERROR]   CollectionAOImplTest.testBulkAddAvuMetadataWithDuplicate:703 expected org.irods.jargon.core.exception.CatalogSQLException to be thrown, but nothing was thrown
[ERROR]   DataObjectAOImplTest.testAddAVUMetadataToDataObjectTwice:2844 unexpected exception type thrown; expected:<org.irods.jargon.core.exception.CatalogSQLException> but was:<org.irods.jargon.core.exception.DuplicateDataException>
[ERROR]   UserAOTest.testAddUserMetadataTwice:1047 unexpected exception type thrown; expected:<org.irods.jargon.core.exception.CatalogSQLException> but was:<org.irods.jargon.core.exception.DuplicateDataException>
[ERROR] Errors:                                                                                
[ERROR]   CollectionAOImplForSoftLinkTest.testFindDifferingMetadataValuesByMetadataQueryCompareSourceAndTarget:245 » InvalidArgument
[ERROR]   CollectionAOImplForSoftLinkTest.testFindMetadataValuesByMetadataQueryCompareSourceAndTarget:182 » InvalidArgument
[ERROR]   CollectionAOImplForSoftLinkTest.testFindMetadataValuesByMetadataQueryForCollectionSoftLinked:84 » InvalidArgument
[ERROR]   CollectionAOImplTest.testBulkDeleteAvuMetadata:516 » InvalidArgument 
[ERROR]   CollectionAOImplTest.testBulkDeleteAvuMetadataCollMissing:647 » InvalidArgument
[ERROR]   CollectionAOImplTest.testDeleteAllAvuMetadata:593 » InvalidArgument 
[ERROR]   CollectionAOImplTest.testFindDomainByMetadataQuery:125 » InvalidArgument 
[ERROR]   CollectionAOImplTest.testFindMetadataValueForCollectionById:305 » InvalidArgument
[ERROR]   CollectionAOImplTest.testFindMetadataValuesByMetadataQuery:199 » InvalidArgument
[ERROR]   CollectionAOImplTest.testFindMetadataValuesByMetadataQueryCaseInsensitive:236 » InvalidArgument
[ERROR]   CollectionAOImplTest.testFindMetadataValuesByMetadataQueryForCollection:270 » InvalidArgument
[ERROR]   CollectionAOImplTest.testFindMetadataValuesByMetadataQueryForCollectionCaseInsensitive:371 » InvalidArgument
[ERROR]   CollectionAOImplTest.testFindMetadataValuesByMetadataQueryTwoConditions:407 » InvalidArgument
[ERROR]   CollectionAOImplTest.testGetPermissionsForCollection:2057 » Jargon Unknown iRO...
[ERROR]   CollectionAOImplTest.testOverwriteAvuMetadataGivenNameAndUnit:1158 » InvalidArgument
[ERROR]   CollectionAOImplTest.testRemoveAvuMetadata:969 » InvalidArgument 
[ERROR]   CollectionAOImplTest.testRemoveAvuMetadataAvuDataDoesNotExist:1219 » InvalidArgument
[ERROR]   CollectionAOImplTest.testRemoveAvuMetadataCollectionNotExists »  Unexpected ex...
[ERROR]   CollectionAOImplTest.testRodsadminCanManipulateMetadataOnCollectionUsingAdminFlag:2420 » InvalidArgument
[ERROR]   DataObjectAOImplForSoftLinkTest.testDeleteAVUMetadataFromDataObjectWhenSoftLinked:231 » InvalidArgument
[ERROR]   DataObjectAOImplTest.testBulkDeleteAVUMetadataFromDataObject:4950 » InvalidArgument
[ERROR]   DataObjectAOImplTest.testDeleteAVUMetadataFromDataObject:2973 » InvalidArgument
[ERROR]   DataObjectAOImplTest.testDeleteAllAVUMetadataFromDataObject:4996 » InvalidArgument
[ERROR]   DataObjectAOImplTest.testFindDomainByMetadataQuery:2102 » InvalidArgument 
[ERROR]   DataObjectAOImplTest.testFindDomainByMetadataQueryBug12:133 » InvalidArgument 
[ERROR]   DataObjectAOImplTest.testFindDomainByMetadataQueryCaseInsensitive:2153 » InvalidArgument
[ERROR]   DataObjectAOImplTest.testFindMetadataValuesByMetadataQuery:1998 » InvalidArgument
[ERROR]   DataObjectAOImplTest.testFindMetadataValuesByMetadataQueryCaseInsensitive:2053 » InvalidArgument
[ERROR]   DataObjectAOImplTest.testFindMetadataValuesForDataObject:1696 » InvalidArgument
[ERROR]   DataObjectAOImplTest.testFindMetadataValuesForDataObjectBug178:1736 » InvalidArgument
[ERROR]   DataObjectAOImplTest.testFindMetadataValuesForDataObjectById:1655 » InvalidArgument
[ERROR]   DataObjectAOImplTest.testFindMetadataValuesForDataObjectDemoRescBug178:1782 » InvalidArgument
[ERROR]   DataObjectAOImplTest.testGetPermissionsForDataObjectForUserViaGroupPermissions:3679 » Jargon
[ERROR]   DataObjectAOImplTest.testListMetadataValuesForDataObject:1821 » InvalidArgument
[ERROR]   DataObjectAOImplTest.testListMetadataValuesForDataObjectAsFile:1956 » InvalidArgument
[ERROR]   DataObjectAOImplTest.testListMetadataValuesForReplicatedDataObjectBug178:1866 » InvalidArgument
[ERROR]   DataObjectAOImplTest.testListMetadataValuesForReplicatedDataObjectBug178ReplFirst:1916 » InvalidArgument
[ERROR]   DataObjectAOImplTest.testListPermissionsForDataObjectLookingForGroupPermissions:3618 » Jargon
[ERROR]   DataObjectAOImplTest.testRemoveAvuMetadataAvuDataDoesNotExist:3880 » InvalidArgument
[ERROR]   DataObjectAOImplTest.testRodsadminCanManipulateMetadataOnDataObjectUsingAdminFlag:5400 » InvalidArgument
[ERROR]   IRODSGenQueryExecutorImplBuilderQueriesTest.testExecuteMetadataQueryWithBetween:280 » InvalidArgument
[ERROR]   IRODSGenQueryExecutorImplBuilderQueriesTest.testExecuteMetadataQueryWithIn:133 » InvalidArgument
[ERROR]   QuotaAOImplTest.testListAllNotRodsadmin »  Unexpected exception, expected<org....
[ERROR]   RemoteExecutionOfCommandsAOImplTest.testExecuteARemoteCommandAndGetStreamGivingCommandNameAndArgs:68 » RemoteScriptExecution
[ERROR]   RemoteExecutionOfCommandsAOImplTest.testExecuteARemoteCommandAndGetStreamGivingCommandNameAndArgsAndHost:97 » RemoteScriptExecution
[ERROR]   RemoteExecutionOfCommandsAOImplTest.testExecuteARemoteCommandAndGetStreamUsingAnIRODSFileAbsPathToAddPhysPathToCommandArgs:184 » RemoteScriptExecution
[ERROR]   RemoteExecutionOfCommandsAOImplTest.testExecuteARemoteCommandAndGetStreamUsingAnIRODSFileAbsPathToDetermineHost:138 » RemoteScriptExecution
[ERROR]   ResourceAOTest.testDeleteResourceMetadataBadResource »  Unexpected exception, ...
[ERROR]   ResourceAOTest.testFindMetadataValuesByMetadataQuery:206 » InvalidArgument 
[ERROR]   ResourceAOTest.testListResourceMetadata:318 » InvalidArgument 
[ERROR]   RuleProcessingAOImplTest.testListAvailableRuleEngines:90 » NullPointer
[ERROR]   UserAOTest.testAddUserMetadata:894 » InvalidArgument 
[ERROR]   UserAOTest.testDeleteUserMetadata:943 » InvalidArgument 
[ERROR]   UserAOTest.testListUserMetadataForId:790 » InvalidArgument 
[ERROR]   UserAOTest.testListUserMetadataForUserName:814 » InvalidArgument 
[ERROR]   UserGroupAOImplTest.testAddUserGroup:219 » Jargon Unknown iRODS exception code...
[ERROR]   UserGroupAOImplTest.testAddUserToGroup:340 » Jargon Unknown iRODS exception co...
[ERROR]   UserGroupAOImplTest.testAddUserToGroupAsGroupAdminBug255:285 » Jargon Unknown ...
[ERROR]   UserGroupAOImplTest.testAddUserToGroupUserDoesNotExist »  Unexpected exception...
[ERROR]   UserGroupAOImplTest.testIsUserInGroup:800 » Jargon Unknown iRODS exception cod...
[ERROR]   UserGroupAOImplTest.testListUserGroupMembersGroupExists:446 » Jargon Unknown i...
[ERROR]   UserGroupAOImplTest.testRemoveUserFromGroup:693 » Jargon Unknown iRODS excepti...
[ERROR]   UserGroupAOImplTest.testRemoveUserFromGroupUserNotExists »  Unexpected excepti...
[ERROR]   UserGroupAOImplTest.testRemoveUserFromGroupUserNotInGroup:767 » Jargon Unknown...
[ERROR]   UserGroupAOImplTest.testRemoveUserGroup:492 » Jargon Unknown iRODS exception c...
[ERROR]   UserGroupAOImplTest.testRemoveUserGroupByName:518 » Jargon Unknown iRODS excep...
[ERROR]   IRODSFileImplTest.testCanReadCollectionViaGroupMembership:184 » Jargon Unknown...
[ERROR]   IRODSFileImplTest.testCanReadCollectionViaGroupMembershipWhenRoot:221 » Jargon
[ERROR]   IRODSFileImplTest.testCanReadViaGroup:93 » Jargon Unknown iRODS exception code...
[ERROR]   RemoteExecuteServiceImplTest.testExecuteHello:82 » RemoteScriptExecution Remot...
[ERROR]   RemoteExecuteServiceImplTest.testExecuteHelloABunchOfTimes:118 » RemoteScriptExecution
[ERROR]   RemoteExecuteServiceImplTest.testExecuteHelloWithHost:380 » RemoteScriptExecution
[ERROR]   RemoteExecuteServiceImplTest.testExecuteHelloWithPathExpectingToSetPhysPathInArg:216 » RemoteScriptExecution
[ERROR]   RemoteExecuteServiceImplTest.testExecuteHelloWithPathUsingPost241APIToDetermineHost:345 » RemoteScriptExecution
[ERROR]   RemoteExecuteServiceImplTest.testExecuteHelloWithPathUsingPost241APIToSetCommandLineArg:281 » RemoteScriptExecution
[ERROR]   RemoteExecuteServiceImplTest.testExecuteHelloWithStreamingOnSmallResultWillNotCauseStreaming:165 » RemoteScriptExecution
[INFO] 
[ERROR] Tests run: 1562, Failures: 4, Errors: 76, Skipped: 5
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Jargon 4.3.6.0-RELEASE:
[INFO] 
[INFO] Jargon ............................................. SUCCESS [  0.003 s]
[INFO] Jargon Core ........................................ FAILURE [31:32 min]
[INFO] Jargon User Tagging ................................ SKIPPED
[INFO] Jargon Data Utils .................................. SKIPPED
[INFO] Jargon Ticket ...................................... SKIPPED
[INFO] Jargon Pool ........................................ SKIPPED
[INFO] Jargon Rule Service ................................ SKIPPED
[INFO] data-profile ....................................... SKIPPED
[INFO] jargon-zipservice .................................. SKIPPED
[INFO] Jargon Metadata Query .............................. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  31:34 min
[INFO] Finished at: 2025-05-25T14:44:05Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.1:test (default-test) on project jargon-core: There are test failures.
[ERROR] 
[ERROR] Please refer to /usr/src/jargon/jargon-core/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :jargon-core
```