### PR TITLE
[510] Escape backslash in password. Remove extra escape from semicolon.

### DIFF
--- a/docker-test-framework/README.md
+++ b/docker-test-framework/README.md
@@ -57,3 +57,31 @@ mvn test \
     -pl jargon-core \
     -am
 ```
+
+## Running PAM Tests
+
+The certificates and PAM configuration must be set up manually to test PAM.  The following steps outline how to do this.
+
+1. Before starting the docker containers, update settings.xml:
+
+```
+<test.option.pam>true</test.option.pam>
+<test.option.ssl.configured>true</test.option.ssl.configured>
+```
+
+2. Start the containers as described above. 
+3. Create the certificates on the catalog provider and configure SSL in the ~irods/.irods/irods_environment.json.
+4. Create the "pam" user in iRODS.
+5. Create the "pam" user on the catalog provider.  Give this user the unix password of "pam=;!\pam" to match the value in the test.
+6. Copy the cert (server.crt) to the maven container and import this into the cacerts file using the following (cacerts password is "changeit").
+
+```
+keytool -import -file /path/to/server.crt -keystore /usr/local/openjdk-11/lib/security/cacerts
+```
+
+7. At this point you should be able to run the PAM authentication tests:
+
+```
+cd /usr/src/jargon
+mvn test -Dtest='PAMAuthTest' -DfailIfNoTests=false -pl jargon-core -am
+```

--- a/jargon-core/src/main/java/org/irods/jargon/core/packinstr/AuthReqPluginRequestInp.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/packinstr/AuthReqPluginRequestInp.java
@@ -61,7 +61,7 @@ public class AuthReqPluginRequestInp extends AbstractIRODSPackingInstruction {
 
 		this.authScheme = authScheme;
 		this.userName = userName;
-		this.password = password.replaceAll(";", "\\\\;");
+		this.password = password;
 
 		setApiNumber(AUTH_REQ_API_NBR);
 		this.timeToLive = timeToLive;

--- a/jargon-core/src/main/java/org/irods/jargon/core/utils/MiscIRODSUtils.java
+++ b/jargon-core/src/main/java/org/irods/jargon/core/utils/MiscIRODSUtils.java
@@ -64,7 +64,7 @@ public class MiscIRODSUtils {
 		StringBuilder sb = new StringBuilder();
 		char[] chars = password.toCharArray();
 		for (char c : chars) {
-			if (c == '@' || c == '=' || c == '&' || c == ';') {
+			if (c == '@' || c == '=' || c == '&' || c == ';' || c == '\\') {
 				sb.append('\\');
 			}
 

--- a/settings.xml
+++ b/settings.xml
@@ -39,7 +39,7 @@ as the operative profile to be used in building and testing jargon against a cho
 				<jargon.test.option.exercise.filesystem.mount>false</jargon.test.option.exercise.filesystem.mount>
 				<test.option.mount.basedir>/var/basedir</test.option.mount.basedir>
 				<jargon.test.pam.user>pam</jargon.test.pam.user>
-				<jargon.test.pam.password>pam=!pam</jargon.test.pam.password>
+				<jargon.test.pam.password>pam=;!\\pam</jargon.test.pam.password>
 				<test.option.pam>false</test.option.pam>
 				<test.option.ssl.configured>false</test.option.ssl.configured>
 				<test.option.distributed.resources>false</test.option.distributed.resources>


### PR DESCRIPTION
This is to fix the backslash in the password.  In addition I noticed when testing that a semicolon is being escaped twice so I fixed that as well.  The removal of the `replaceAll()` in `AuthReqPluginRequestInp.java` is done because MiscIRODSUtils.java already handles the escape of the semicolon. 